### PR TITLE
Enable the vyper v0.3.10 support

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@
 <!-- Check your PR fulfills the following items. -->
 <!-- For draft PRs check the boxes as you complete them. -->
 
-- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
+- [ ] PR title corresponds to the body of PR.
 - [ ] Tests for the changes have been added / updated.
 - [ ] Documentation comments have been added / updated.
 - [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # The `zkvyper` changelog
 
+## [Unreleased]
+
+### Added
+
+- The vyper v0.3.10 support
+
 ## [1.3.11] - 2023-10-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "compiler-vyper"
-version = "1.3.11"
+version = "1.3.12"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-vyper"
-version = "1.3.11"
+version = "1.3.12"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
 ]

--- a/src/tests/builtins.rs
+++ b/src/tests/builtins.rs
@@ -17,7 +17,7 @@ def f():
     let _ = super::build_vyper(
         source_code,
         Some((
-            semver::Version::new(0, 3, 9),
+            semver::Version::new(0, 3, 10),
             "Built-in function `create_copy_of` is not supported",
         )),
         compiler_llvm_context::OptimizerSettings::none(),
@@ -38,7 +38,7 @@ def f():
     let _ = super::build_vyper(
         source_code,
         Some((
-            semver::Version::new(0, 3, 9),
+            semver::Version::new(0, 3, 10),
             "Built-in function `create_from_blueprint` is not supported",
         )),
         compiler_llvm_context::OptimizerSettings::none(),

--- a/src/tests/unsupported_opcodes.rs
+++ b/src/tests/unsupported_opcodes.rs
@@ -22,7 +22,7 @@ def f():
     super::build_vyper(
         source_code,
         Some((
-            semver::Version::new(0, 3, 9),
+            semver::Version::new(0, 3, 10),
             "The `EXTCODECOPY` instruction is not supported",
         )),
         compiler_llvm_context::OptimizerSettings::none(),

--- a/src/vyper/mod.rs
+++ b/src/vyper/mod.rs
@@ -41,10 +41,10 @@ impl Compiler {
     pub const DEFAULT_EXECUTABLE_NAME: &'static str = "vyper";
 
     /// The supported versions of `vyper`.
-    pub const SUPPORTED_VERSIONS: [semver::Version; 2 /* 3 */] = [
+    pub const SUPPORTED_VERSIONS: [semver::Version; 3] = [
         semver::Version::new(0, 3, 3),
         semver::Version::new(0, 3, 9),
-        // semver::Version::new(0, 3, 10),
+        semver::Version::new(0, 3, 10),
     ];
 
     ///


### PR DESCRIPTION
# What ❔

This patch enables the vyper v0.3.10 support.

## Why ❔

Vyper 0.3.10 features were already supported but not enabled yet, as the updated was not officially released yet.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
