### PR TITLE
ci: add the binaries release workflow

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -1,0 +1,483 @@
+# TODO: refactor ugly copy-pasted build jobs
+name: Build and release binaries
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git REF to use for manual pre-release"
+        required: true
+        type: string
+      prerelease_suffix:
+        description: "Suffix which has been used for manual pre-release name"
+        required: false
+        type: string
+        default: "notag"
+      release_macos_amd64:
+        description: "Release for MacOS amd64?"
+        required: false
+        type: boolean
+        default: true
+      release_macos_arm64:
+        description: "Release for MacOS arm64?"
+        required: false
+        type: boolean
+        default: true
+      release_linux_amd64:
+        description: "Release for Linux amd64?"
+        required: false
+        type: boolean
+        default: true
+      release_linux_arm64:
+        description: "Release for Linux arm64?"
+        required: false
+        type: boolean
+        default: true
+      release_windows_amd64:
+        description: "Release for Windows amd64?"
+        required: false
+        type: boolean
+        default: true
+
+  push:
+    tags:
+      - "v*.*.*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_macos_arm64:
+    if: github.event.inputs.release_macos_arm64 || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    runs-on: [self-hosted, macOS, ARM64]
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
+    steps:
+      - name: Cleanup workspace
+        shell: zsh {0}
+        run: |
+          setopt rmstarsilent
+          setopt +o nomatch
+          rm -rf ${{ github.workspace }}/*
+
+      - name: Checkout source
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
+
+      - name: Build LLVM framework
+        shell: zsh {0}
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+        run: |
+          cargo install compiler-llvm-builder
+          zkevm-llvm clone
+          zkevm-llvm build
+
+      - name: Build compiler
+        shell: zsh {0}
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+        run: |
+          cargo build --release
+
+      - name: Prepare binary file name
+        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        shell: zsh {0}
+        run: |
+          mkdir -p ./releases/macosx-arm64
+          strip ./target/release/zkvyper
+          mv ./target/release/zkvyper ./releases/macosx-arm64/zkvyper-macosx-arm64-${{ github.ref_name }}
+
+      - name: Prepare binary file name
+        if: github.event_name == 'workflow_dispatch'
+        shell: zsh {0}
+        run: |
+          mkdir -p ./releases/macosx-arm64
+          strip ./target/release/zkvyper
+          mv ./target/release/zkvyper ./releases/macosx-arm64/zkvyper-macosx-arm64
+
+      - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3
+        with:
+          name: release_macos_arm64
+          path: releases
+
+      # Always removing global git config since it breakes next checkout action and local config does not work with cargo for some reason
+      - name: Cleanup leftovers
+        shell: zsh {0}
+        if: always()
+        run: |
+          rm -rf ~/.gitconfig
+
+  build_macos_amd64:
+    if: github.event.inputs.release_macos_amd64 || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    runs-on: macos-12-large
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
+
+      - name: Prepare environment
+        shell: zsh {0}
+        run: |
+          brew install cmake ninja
+
+      - name: Build LLVM framework
+        shell: zsh {0}
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+        run: |
+          cargo install compiler-llvm-builder
+          zkevm-llvm clone
+          zkevm-llvm build
+
+      - name: Build compiler
+        shell: zsh {0}
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+        run: |
+          cargo build --release
+
+      - name: Prepare binary file name
+        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        shell: zsh {0}
+        run: |
+          mkdir -p ./releases/macosx-amd64
+          mv ./target/release/zkvyper ./releases/macosx-amd64/zkvyper-macosx-amd64-${{ github.ref_name }}
+
+      - name: Prepare binary file name
+        if: github.event_name == 'workflow_dispatch'
+        shell: zsh {0}
+        run: |
+          mkdir -p ./releases/macosx-amd64
+          mv ./target/release/zkvyper ./releases/macosx-amd64/zkvyper-macosx-amd64
+
+      - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3
+        with:
+          name: release_macos_amd64
+          path: releases
+
+  build_linux_amd64:
+    if: github.event.inputs.release_linux_amd64 || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    runs-on: [matterlabs-ci-runner]
+    container:
+      image: matterlabs/llvm_runner:latest
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USER }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - musl
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
+
+      - name: Prepare environment
+        run: |
+          rustup target add x86_64-unknown-linux-${{ matrix.target }}
+
+      - name: Build LLVM framework
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+        run: |
+          cargo install compiler-llvm-builder --target x86_64-unknown-linux-${{ matrix.target }}
+          export PATH="${PATH}:/usr/local/cargo/bin/"
+          zkevm-llvm clone
+          zkevm-llvm build
+
+      - name: Build compiler
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+        run: |
+          cargo build --release --target x86_64-unknown-linux-${{ matrix.target }}
+
+      - name: Prepare binary file name
+        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        run: |
+          mkdir -p releases/linux-amd64
+          mv ./target/x86_64-unknown-linux-${{ matrix.target }}/release/zkvyper releases/linux-amd64/zkvyper-linux-amd64-${{ matrix.target }}-${{ github.ref_name }}
+
+      - name: Prepare binary file name
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          mkdir -p releases/linux-amd64
+          mv ./target/x86_64-unknown-linux-${{ matrix.target }}/release/zkvyper releases/linux-amd64/zkvyper-linux-amd64-${{ matrix.target }}
+
+      - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3
+        with:
+          name: release_linux_amd64
+          path: releases
+
+  build_linux_arm64:
+    if: github.event.inputs.release_linux_arm64 || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    runs-on: matterlabs-ci-runner-arm
+    container:
+      image: matterlabs/llvm_runner_jammy:latest
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USER }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - musl
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
+
+      - name: Prepare environment
+        run: |
+          rustup target add aarch64-unknown-linux-${{ matrix.target }}
+
+      - name: Build LLVM framework
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+        run: |
+          cargo install compiler-llvm-builder --target aarch64-unknown-linux-${{ matrix.target }}
+          export PATH="${PATH}:/usr/local/cargo/bin/"
+          zkevm-llvm clone
+          zkevm-llvm build
+
+      - name: Build compiler
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+          # lib path might change over time since LLVM 15 version is not strictly pinned in our CI runner image
+          # https://github.com/rust-lang/rust/issues/89626#issuecomment-1727368240
+          RUSTFLAGS: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
+        run: |
+          cargo build --release --target aarch64-unknown-linux-${{ matrix.target }}
+
+      - name: Prepare binary file name
+        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        run: |
+          mkdir -p releases/linux-arm64
+          mv ./target/aarch64-unknown-linux-${{ matrix.target }}/release/zkvyper releases/linux-arm64/zkvyper-linux-arm64-${{ matrix.target }}-${{ github.ref_name }}
+
+      - name: Prepare binary file name
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          mkdir -p releases/linux-arm64
+          mv ./target/aarch64-unknown-linux-${{ matrix.target }}/release/zkvyper releases/linux-arm64/zkvyper-linux-arm64-${{ matrix.target }}
+
+      - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3
+        with:
+          name: release_linux_arm64
+          path: releases
+
+  build_windows_amd64:
+    if: github.event.inputs.release_windows_amd64 || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    runs-on: windows-2022-github-hosted-16core
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
+      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
+
+      - name: Prepare msys2
+        uses: msys2/setup-msys2@d40200dc2db4c351366b048a9565ad82919e1c24
+
+      - name: Update pacman keys
+        shell: msys2 {0}
+        run: |
+          pacman-key --refresh
+
+      - name: Update pacman deps
+        shell: msys2 {0}
+        run: |
+          pacman -Sy
+
+      - name: Install msys deps
+        shell: msys2 {0}
+        run: |
+          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+          pacman --noconfirm -S --needed --overwrite \
+          base-devel \
+          git \
+          ninja \
+          mingw-w64-x86_64-clang \
+          mingw-w64-x86_64-lld \
+          mingw-w64-x86_64-rust \
+          mingw-w64-x86_64-gcc-libs \
+          mingw-w64-x86_64-gcc
+
+      - name: Build LLVM framework
+        shell: msys2 {0}
+        run: |
+          cargo install compiler-llvm-builder
+          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
+          zkevm-llvm clone
+          zkevm-llvm build
+
+      - name: Build compiler
+        shell: msys2 {0}
+        run: |
+          cargo build --release
+
+      - name: Prepare binary file name
+        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        run: |
+          mkdir -p releases/windows-amd64
+          mv ./target/release/zkvyper.exe releases/windows-amd64/zkvyper-windows-amd64-gnu-${{ github.ref_name }}.exe
+
+      - name: Prepare binary file name
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          mkdir -p releases/windows-amd64
+          mv ./target/release/zkvyper.exe releases/windows-amd64/zkvyper-windows-amd64-gnu.exe
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: release_windows_amd64
+          path: releases
+
+  prepare_release:
+    runs-on: ubuntu-latest
+    needs:
+      - build_macos_arm64
+      - build_macos_amd64
+      - build_linux_amd64
+      - build_linux_arm64
+      - build_windows_amd64
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
+
+      - name: Download MacOS arm64 artifact
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7
+        with:
+          name: release_macos_arm64
+          path: releases
+
+      - name: Download MacOS amd64 artifact
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7
+        with:
+          name: release_macos_amd64
+          path: releases
+
+      - name: Download Linux arm64 artifact
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7
+        with:
+          name: release_linux_arm64
+          path: releases
+
+      - name: Download Linux amd64 artifact
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7
+        with:
+          name: release_linux_amd64
+          path: releases
+
+      - name: Download Windows amd64 artifact
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7
+        with:
+          name: release_windows_amd64
+          path: releases
+
+      - name: Checkout repo with binaries
+        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3
+        with:
+          repository: matter-labs/zkvyper-bin
+          path: public_repo
+          ref: main
+
+      - name: Generate Version or SHA
+        id: version_or_sha
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            git config --global --add safe.directory $GITHUB_WORKSPACE
+            echo "version_or_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          else
+            echo "version_or_sha=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: List binaries to be released
+        run: tree ./releases
+
+      - name: Publish pre-release
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+            BINARIES=($(find ./releases -type f))
+            gh release create --prerelease prerelease-${{ steps.version_or_sha.outputs.version_or_sha }}-${{ github.event.inputs.prerelease_suffix }} \
+              --target ${{ github.event.inputs.ref }} --title prerelease-${{ steps.version_or_sha.outputs.version_or_sha }}-${{ github.event.inputs.prerelease_suffix }} \
+              "${BINARIES[@]}"
+
+      # to-do rename step after depcreation - matter-labs/zksolc-bin
+      - name: Publish release (this repository)
+        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+            BINARIES=($(find ./releases -type f))
+            gh release create ${{ steps.version_or_sha.outputs.version_or_sha }} \
+              --title ${{ steps.version_or_sha.outputs.version_or_sha }} \
+              "${BINARIES[@]}"
+
+      - name: Publish release
+        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        run: |
+            chmod -R +x releases/
+            cp -R releases/* public_repo/
+            cd public_repo
+            git config --global user.email "dev-robot@matterlabs.dev"
+            git config --global user.name "zksync-admin-bot2"
+            git add .
+            git commit -m "Release: ${{ steps.version_or_sha.outputs.version_or_sha }}"
+            git push
+
+      - name: Get CHANGELOG Entry
+        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          validation_level: warn
+          path: ./CHANGELOG.md
+
+      - name: Prepare CHANGELOG for publishing
+        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        run: |
+          echo "## ${{ github.event.repository.name }}" >> ./release_changelog.md
+          echo "## [${{ steps.changelog_reader.outputs.version }}] - ${{ steps.changelog_reader.outputs.date }}" >> ./release_changelog.md
+          echo '${{ steps.changelog_reader.outputs.changes }}' >> ./release_changelog.md
+
+      - name: Create the Mattermost Message
+        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        run: |
+          echo "{\"text\":\"$(cat ./release_changelog.md)\"}" > mattermost.json
+          cat mattermost.json
+
+      - uses: mattermost/action-mattermost-notify@master
+        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        env:
+          MATTERMOST_USERNAME: "Compiler Release Bot"
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_URL }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@
 # IDE project data
 /.idea/
 /.vscode/
-


### PR DESCRIPTION
# What ❔

Migrates the CI workflows from the private repos.

## Why ❔

We are going to release all binaries from this open-source repository from now on.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
