### PR TITLE
ci: add unit tests workflow

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -51,16 +51,15 @@ jobs:
       - name: Prepare environment
         run: |
           brew install cmake ninja
-      - name: Clone LLVM framework
-        run: |
-          cargo install compiler-llvm-builder
-          zkevm-llvm clone
       - name: Build LLVM framework
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 60
           max_attempts: 2 # protection mechanism for sporadic dependencies download failure
-          command: zkevm-llvm build
+          command: |
+            cargo install compiler-llvm-builder
+            zkevm-llvm clone
+            zkevm-llvm build
       - name: Install vyper compiler
         run: |
           curl --location -o "${PWD}/vyper" \
@@ -169,8 +168,8 @@ jobs:
         run: |
           pacman-key --refresh
           pacman -Sy
-          curl --location -o "${MINGW64_DOWNLOAD_LINK}/${MINGW64_DOWNLOAD_FILENAME}"
-          pacman --noconfirm -U ${MINGW64_DOWNLOAD_FILENAME}
+          curl --location -o "${MINGW64_DOWNLOAD_URL}/${MINGW64_DOWNLOAD_FILENAME}"
+          pacman --noconfirm -U "${MINGW64_DOWNLOAD_FILENAME}"
           pacman --noconfirm -S --needed --overwrite \
             base-devel \
             git \

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -21,130 +21,130 @@ env:
   RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
 
 jobs:
-#  unit-tests-macos:
-#    strategy:
-#      matrix:
-#        include:
-#          - name: "MacOS x86"
-#            runner: macos-12-large
-#          - name: "MacOS arm64"
-#            runner: [self-hosted, macOS, ARM64]
-#    runs-on: ${{ matrix.runner }}
-#    name: ${{ matrix.name }}
-#    defaults:
-#      run:
-#        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
-#    env:
-#      VYPER_DOWNLOAD_EXTENSION: ".darwin"
-#    steps:
-#      # TODO: This step should be done as part of github runners hooks
-#      # Users should always expect clean workspace when a new job starts
-#      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
-#      - name: Cleanup workspace
-#        if: ${{ matrix.name }} == "MacOS ARM64"
-#        run: |
-#          setopt rmstarsilent # Do not query the user before executing rm * or rm path/*.
-#          setopt +o nomatch
-#          rm -rf ${{ github.workspace }}/*
-#      - name: Checkout source
-#        uses: actions/checkout@v4
-#      - name: Prepare environment
-#        run: |
-#          brew install cmake ninja
-#      - name: Clone LLVM framework
-#        run: |
-#          cargo install compiler-llvm-builder
-#          zkevm-llvm clone
-#      - name: Build LLVM framework
-#        run: |
-#          zkevm-llvm build
-#      - name: Install vyper compiler
-#        run: |
-#          curl --location -o "${PWD}/vyper" \
-#            "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}"
-#          chmod a+x "${PWD}/vyper"
-#          echo "${PWD}" >> "${GITHUB_PATH}"
-#      - name: Build zkvyper
-#        run: |
-#          cargo build --release
-#          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
-#      - name: Install junit converter
-#        run: cargo install cargo2junit
-#      - name: Run unit tests
-#        run: |
-#          cargo test --verbose -- -Z unstable-options --format json | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
-#      - name: Upload test results
-#        if: always()
-#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-#        with:
-#          check_name: ${{ matrix.name }} Unit Tests Results
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-#          action_fail_on_inconclusive: true
-#
-#  unit-tests-linux:
-#    strategy:
-#      matrix:
-#        include:
-#          - name: "Linux x86"
-#            runner: matterlabs-ci-runner
-#            target: "x86_64-unknown-linux-musl"
-##          TODO: uncomment and parametrize VYPER_DOWNLOAD_EXTENSION when arm64 linux vyper executable is available
-##          Linux ARM64 is not supported yet due to lack of Vyper executable for Linux arm64
-##          - name: "Linux arm64"
-##            runner: matterlabs-ci-runner-arm
-##            target: "aarch64-unknown-linux-musl"
-##            rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
-#    runs-on: ${{ matrix.runner }}
-#    name: ${{ matrix.name }}
-#    container:
-#      image: matterlabs/llvm_runner_jammy:latest
-#      credentials:
-#        username: ${{ secrets.DOCKERHUB_USER }}
-#        password: ${{ secrets.DOCKERHUB_TOKEN }}
-#    env:
-#      RUSTFLAGS: ${{ matrix.rustflags }}
-#      VYPER_DOWNLOAD_EXTENSION: ".linux"
-#    steps:
-#      - name: Checkout source
-#        uses: actions/checkout@v4
-#      - name: Prepare environment
-#        run: |
-#          rustup target add ${{ matrix.target }}
-#      - name: Install vyper compiler
-#        run: |
-#          curl --location -o "${PWD}/vyper" \
-#            "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}"
-#          chmod a+x "${PWD}/vyper"
-#          echo "${PWD}" >> "${GITHUB_PATH}"
-#      - name: Clone LLVM framework
-#        run: |
-#          cargo install compiler-llvm-builder --target ${{ matrix.target }}
-#          zkevm-llvm clone
-#      - name: Build LLVM framework
-#        uses: nick-fields/retry@v2
-#        with:
-#          timeout_minutes: 60
-#          max_attempts: 2 # protection mechanism for sporadic dependencies download failure
-#          command: zkevm-llvm build
-#      - name: Build zkvyper
-#        run: |
-#          cargo build --release --target ${{ matrix.target }}
-#          echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
-#      - name: Install junit converter
-#        run: cargo install cargo2junit
-#      - name: Run unit tests
-#        run: |
-#          cargo test --verbose --target ${{ matrix.target }} -- -Z unstable-options --format json | \
-#            cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
-#      - name: Upload test results
-#        if: always()
-#        uses: EnricoMi/publish-unit-test-result-action@v2
-#        with:
-#          check_name: ${{ matrix.name }} Unit Tests Results
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-#          action_fail_on_inconclusive: true
+  unit-tests-macos:
+    strategy:
+      matrix:
+        include:
+          - name: "MacOS x86"
+            runner: macos-12-large
+          - name: "MacOS arm64"
+            runner: [self-hosted, macOS, ARM64]
+    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.name }}
+    defaults:
+      run:
+        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
+    env:
+      VYPER_DOWNLOAD_EXTENSION: ".darwin"
+    steps:
+      # TODO: This step should be done as part of github runners hooks
+      # Users should always expect clean workspace when a new job starts
+      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
+      - name: Cleanup workspace
+        if: ${{ matrix.name }} == "MacOS ARM64"
+        run: |
+          setopt rmstarsilent # Do not query the user before executing rm * or rm path/*.
+          setopt +o nomatch
+          rm -rf ${{ github.workspace }}/*
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Prepare environment
+        run: |
+          brew install cmake ninja
+      - name: Clone LLVM framework
+        run: |
+          cargo install compiler-llvm-builder
+          zkevm-llvm clone
+      - name: Build LLVM framework
+        run: |
+          zkevm-llvm build
+      - name: Install vyper compiler
+        run: |
+          curl --location -o "${PWD}/vyper" \
+            "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}"
+          chmod a+x "${PWD}/vyper"
+          echo "${PWD}" >> "${GITHUB_PATH}"
+      - name: Build zkvyper
+        run: |
+          cargo build --release
+          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
+      - name: Install junit converter
+        run: cargo install cargo2junit
+      - name: Run unit tests
+        run: |
+          cargo test --verbose -- -Z unstable-options --format json | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
+      - name: Upload test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        with:
+          check_name: ${{ matrix.name }} Unit Tests Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+          action_fail_on_inconclusive: true
+
+  unit-tests-linux:
+    strategy:
+      matrix:
+        include:
+          - name: "Linux x86"
+            runner: matterlabs-ci-runner
+            target: "x86_64-unknown-linux-musl"
+#          TODO: uncomment and parametrize VYPER_DOWNLOAD_EXTENSION when arm64 linux vyper executable is available
+#          Linux ARM64 is not supported yet due to lack of Vyper executable for Linux arm64
+#          - name: "Linux arm64"
+#            runner: matterlabs-ci-runner-arm
+#            target: "aarch64-unknown-linux-musl"
+#            rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
+    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.name }}
+    container:
+      image: matterlabs/llvm_runner_jammy:latest
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USER }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    env:
+      RUSTFLAGS: ${{ matrix.rustflags }}
+      VYPER_DOWNLOAD_EXTENSION: ".linux"
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Prepare environment
+        run: |
+          rustup target add ${{ matrix.target }}
+      - name: Install vyper compiler
+        run: |
+          curl --location -o "${PWD}/vyper" \
+            "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}"
+          chmod a+x "${PWD}/vyper"
+          echo "${PWD}" >> "${GITHUB_PATH}"
+      - name: Clone LLVM framework
+        run: |
+          cargo install compiler-llvm-builder --target ${{ matrix.target }}
+          zkevm-llvm clone
+      - name: Build LLVM framework
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 2 # protection mechanism for sporadic dependencies download failure
+          command: zkevm-llvm build
+      - name: Build zkvyper
+        run: |
+          cargo build --release --target ${{ matrix.target }}
+          echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
+      - name: Install junit converter
+        run: cargo install cargo2junit
+      - name: Run unit tests
+        run: |
+          cargo test --verbose --target ${{ matrix.target }} -- -Z unstable-options --format json | \
+            cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
+      - name: Upload test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          check_name: ${{ matrix.name }} Unit Tests Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+          action_fail_on_inconclusive: true
 
   unit-tests-windows:
     name: "Windows"
@@ -166,9 +166,8 @@ jobs:
         run: |
           pacman-key --refresh
           pacman -Sy
-          echo ${MINGW64_DOWNLOAD_URL}/${MINGW64_DOWNLOAD_FILENAME}
-          curl --location -o ${MINGW64_DOWNLOAD_URL}/${MINGW64_DOWNLOAD_FILENAME}
-          pacman --noconfirm -U ${MINGW64_DOWNLOAD_FILENAME}
+          curl -LO "$MINGW64_DOWNLOAD_URL/$MINGW64_DOWNLOAD_FILENAME"
+          pacman --noconfirm -U "$MINGW64_DOWNLOAD_FILENAME"
           pacman --noconfirm -S --needed --overwrite \
             base-devel \
             git \

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -11,7 +11,6 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false # for now, false (put jobs in queue) allowing multiple PR testing consequently
-# https://github.com/vyperlang/vyper/releases/download/v0.3.10/vyper.0.3.10+commit.91361694.darwin
 env:
   VYPER_VERSION: "v0.3.10"
   VYPER_DOWNLOAD_URL: "https://github.com/vyperlang/vyper/releases/download"
@@ -50,31 +49,24 @@ jobs:
       - name: Prepare environment
         run: |
           brew install cmake ninja
-          echo "CMake version: \`$(cmake --version | head -1 | cut -d ' ' -f3)\`" >> "${GITHUB_STEP_SUMMARY}"
-          echo "Ninja version: \`$(ninja --version)\`" >> "${GITHUB_STEP_SUMMARY}"
       - name: Build LLVM framework
         run: |
           cargo install compiler-llvm-builder
           zkevm-llvm clone
           zkevm-llvm build
-      - name: Install solc compiler
+      - name: Install vyper compiler
         run: |
           curl --verbose \
             --location -o "${PWD}/vyper" "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}" && \
             chmod a+x "${PWD}/vyper"
           echo "${PWD}" >> "${GITHUB_PATH}"
-          echo "Vyper version: \`$(vyper --version)\`" >> "${GITHUB_STEP_SUMMARY}"
       - name: Build zkvyper
         run: |
           cargo build -vv --release
           echo "${PWD}/target/release" >> "${GITHUB_PATH}"
-          echo "$(zkvyper --version)" >> "${GITHUB_STEP_SUMMARY}"
       - name: Run unit tests
         run: |
-          set -x
           cargo install cargo2junit
-          which vyper
-          which zkvyper
           cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
         if: always()
@@ -85,114 +77,114 @@ jobs:
           files: ${{ env.UNIT_TESTS_RESULTS_XML }}
           action_fail_on_inconclusive: true
 
-#  unit-tests-linux:
-#    strategy:
-#      matrix:
-#        include:
-#          - name: "Linux x86"
-#            runner: matterlabs-ci-runner
-#            solc-name: "solc-linux-amd64"
-#            target: "x86_64-unknown-linux-musl"
-#          - name: "Linux arm64"
-#            runner: matterlabs-ci-runner-arm
-#            solc-name: "solc-linux-arm64"
-#            target: "aarch64-unknown-linux-musl"
-#            rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
-#    runs-on: ${{ matrix.runner }}
-#    name: ${{ matrix.name }}
-#    container:
-#      image: matterlabs/llvm_runner_jammy:latest
-#      credentials:
-#        username: ${{ secrets.DOCKERHUB_USER }}
-#        password: ${{ secrets.DOCKERHUB_TOKEN }}
-#    env:
-#      RUSTFLAGS: ${{ matrix.rustflags }}
-#    steps:
-#      - name: Checkout source
-#        uses: actions/checkout@v4
-#      - name: Prepare environment
-#        run: |
-#          rustup target add ${{ matrix.target }}
-#      - name: Install solc compiler
-#        run: |
-#          curl --verbose \
-#            --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
-#            chmod a+x "${PWD}/solc"
-#          echo "${PWD}" >> "${GITHUB_PATH}"
-#      - name: Build LLVM framework
-#        run: |
-#          cargo install compiler-llvm-builder --target ${{ matrix.target }}
-#          zkevm-llvm clone
-#          zkevm-llvm build
-#      - name: Build zksolc
-#        run: |
-#          cargo build -vv --release --target ${{ matrix.target }}
-#          echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
-#      - name: Run unit tests
-#        run: |
-#          cargo install cargo2junit
-#          cargo test --verbose --target ${{ matrix.target }} -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-#          cat "${UNIT_TESTS_RESULTS_XML}"
-#      - name: Upload test results
-#        if: always()
-#        uses: EnricoMi/publish-unit-test-result-action@v2
-#        with:
-#          check_name: ${{ matrix.name }} Unit Tests Results
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-#          action_fail_on_inconclusive: true
+  unit-tests-linux:
+    strategy:
+      matrix:
+        include:
+          - name: "Linux x86"
+            runner: matterlabs-ci-runner
+            target: "x86_64-unknown-linux-musl"
+          - name: "Linux arm64"
+            runner: matterlabs-ci-runner-arm
+            target: "aarch64-unknown-linux-musl"
+            rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
+    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.name }}
+    container:
+      image: matterlabs/llvm_runner_jammy:latest
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USER }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    env:
+      RUSTFLAGS: ${{ matrix.rustflags }}
+      VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694.linux"
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Prepare environment
+        run: |
+          rustup target add ${{ matrix.target }}
+      - name: Install vyper compiler
+        run: |
+          curl --verbose \
+            --location -o "${PWD}/vyper" "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}" && \
+            chmod a+x "${PWD}/vyper"
+          echo "${PWD}" >> "${GITHUB_PATH}"
+      - name: Build LLVM framework
+        run: |
+          cargo install compiler-llvm-builder --target ${{ matrix.target }}
+          zkevm-llvm clone
+          zkevm-llvm build
+      - name: Build zkvyper
+        run: |
+          cargo build -vv --release --target ${{ matrix.target }}
+          echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
+      - name: Run unit tests
+        run: |
+          cargo install cargo2junit
+          cargo test --verbose --target ${{ matrix.target }} -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+          cat "${UNIT_TESTS_RESULTS_XML}"
+      - name: Upload test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          check_name: ${{ matrix.name }} Unit Tests Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+          action_fail_on_inconclusive: true
 
-#  unit-tests-windows:
-#    name: "Windows"
-#    runs-on: windows-2022-github-hosted-16core
-#    env:
-#      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
-#    defaults:
-#      run:
-#        shell: msys2 {0}
-#    steps:
-#      - name: Checkout source
-#        uses: actions/checkout@v4
-#      - name: Prepare msys2
-#        uses: msys2/setup-msys2@v2
-#      - name: Prepare env
-#        run: |
-#          pacman-key --refresh
-#          pacman -Sy
-#          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-#          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-#          pacman --noconfirm -S --needed --overwrite \
-#          base-devel \
-#          git \
-#          ninja \
-#          mingw-w64-x86_64-clang \
-#          mingw-w64-x86_64-lld \
-#          mingw-w64-x86_64-rust \
-#          mingw-w64-x86_64-gcc-libs \
-#          mingw-w64-x86_64-gcc
-#      - name: Install solc compiler
-#        run: |
-#          curl --verbose --location -o solc.exe "${SOLC_URL}/${SOLC_VERSION}/solc-windows-amd64-${SOLC_VERSION}.exe"
-#      - name: Build LLVM framework
-#        run: |
-#          cargo install compiler-llvm-builder
-#          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
-#          zkevm-llvm clone
-#          zkevm-llvm build
-#      - name: Build compiler
-#        run: |
-#          cargo build -vv --release
-#      - name: Run unit tests
-#        run: |
-#          cargo install cargo2junit
-#          export PATH="$PWD/target/release:$PWD:$PATH:/c/Users/runneradmin/.cargo/bin/"
-#          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-#          cat "${UNIT_TESTS_RESULTS_XML}"
-#      - name: Upload test results
-#        if: always()
-#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-#        with:
-#          check_name: Windows Unit Tests Results
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-#          action_fail_on_inconclusive: true
+  unit-tests-windows:
+    name: "Windows"
+    runs-on: windows-2022-github-hosted-16core
+    env:
+      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
+      VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694.windows.exe"
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Prepare msys2
+        uses: msys2/setup-msys2@v2
+      - name: Prepare env
+        run: |
+          pacman-key --refresh
+          pacman -Sy
+          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+          pacman --noconfirm -S --needed --overwrite \
+          base-devel \
+          git \
+          ninja \
+          mingw-w64-x86_64-clang \
+          mingw-w64-x86_64-lld \
+          mingw-w64-x86_64-rust \
+          mingw-w64-x86_64-gcc-libs \
+          mingw-w64-x86_64-gcc
+      - name: Install vyper compiler
+        run: |
+          curl --verbose --location -o vyper.exe "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}"
+      - name: Build LLVM framework
+        run: |
+          cargo install compiler-llvm-builder
+          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
+          zkevm-llvm clone
+          zkevm-llvm build
+      - name: Build compiler
+        run: |
+          cargo build -vv --release
+      - name: Run unit tests
+        run: |
+          cargo install cargo2junit
+          export PATH="$PWD/target/release:$PWD:$PATH:/c/Users/runneradmin/.cargo/bin/"
+          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+          cat "${UNIT_TESTS_RESULTS_XML}"
+      - name: Upload test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        with:
+          check_name: Windows Unit Tests Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+          action_fail_on_inconclusive: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,198 @@
+name: Unit Tests
+
+# Execute workflow for each PR and with each merge to the trunk
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+# Cancel the workflow if any new changes pushed to a feature branch or the trunk
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false # for now, false (put jobs in queue) allowing multiple PR testing consequently
+# https://github.com/vyperlang/vyper/releases/download/v0.3.10/vyper.0.3.10+commit.91361694.darwin
+env:
+  VYPER_VERSION: "v0.3.10"
+  VYPER_DOWNLOAD_URL: "https://github.com/vyperlang/vyper/releases/download"
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+  UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
+  RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
+
+jobs:
+  unit-tests-macos:
+    strategy:
+      matrix:
+        include:
+          - name: "MacOS x86"
+            runner: macos-12-large
+          - name: "MacOS arm64"
+            runner: [self-hosted, macOS, ARM64]
+    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.name }}
+    defaults:
+      run:
+        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
+    env:
+      VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694.darwin"
+    steps:
+      # TODO: This step should be done as part of github runners hooks
+      # Users should always expect clean workspace when a new job starts
+      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
+      - name: Cleanup workspace
+        if: ${{ matrix.name }} == "MacOS ARM64"
+        run: |
+          setopt rmstarsilent
+          setopt +o nomatch
+          rm -rf ${{ github.workspace }}/*
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Prepare environment
+        run: |
+          brew install cmake ninja
+          echo "CMake version: \`$(cmake --version | head -1 | cut -d ' ' -f3)\`" >> "${GITHUB_STEP_SUMMARY}"
+          echo "Ninja version: \`$(ninja --version)\`" >> "${GITHUB_STEP_SUMMARY}"
+      - name: Build LLVM framework
+        run: |
+          cargo install compiler-llvm-builder
+          zkevm-llvm clone
+          zkevm-llvm build
+      - name: Install solc compiler
+        run: |
+          curl --verbose \
+            --location -o "${PWD}/vyper" "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}" && \
+            chmod a+x "${PWD}/vyper"
+          echo "${PWD}" >> "${GITHUB_PATH}"
+          echo "Vyper version: \`$(vyper --version)\`" >> "${GITHUB_STEP_SUMMARY}"
+      - name: Build zkvyper
+        run: |
+          cargo build -vv --release
+          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
+          echo "$(zkvyper --version)" >> "${GITHUB_STEP_SUMMARY}"
+      - name: Run unit tests
+        run: |
+          set -x
+          cargo install cargo2junit
+          which vyper
+          which zkvyper
+          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+      - name: Upload test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        with:
+          check_name: ${{ matrix.name }} Unit Tests Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+          action_fail_on_inconclusive: true
+
+#  unit-tests-linux:
+#    strategy:
+#      matrix:
+#        include:
+#          - name: "Linux x86"
+#            runner: matterlabs-ci-runner
+#            solc-name: "solc-linux-amd64"
+#            target: "x86_64-unknown-linux-musl"
+#          - name: "Linux arm64"
+#            runner: matterlabs-ci-runner-arm
+#            solc-name: "solc-linux-arm64"
+#            target: "aarch64-unknown-linux-musl"
+#            rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
+#    runs-on: ${{ matrix.runner }}
+#    name: ${{ matrix.name }}
+#    container:
+#      image: matterlabs/llvm_runner_jammy:latest
+#      credentials:
+#        username: ${{ secrets.DOCKERHUB_USER }}
+#        password: ${{ secrets.DOCKERHUB_TOKEN }}
+#    env:
+#      RUSTFLAGS: ${{ matrix.rustflags }}
+#    steps:
+#      - name: Checkout source
+#        uses: actions/checkout@v4
+#      - name: Prepare environment
+#        run: |
+#          rustup target add ${{ matrix.target }}
+#      - name: Install solc compiler
+#        run: |
+#          curl --verbose \
+#            --location -o "${PWD}/solc" "${SOLC_URL}/${SOLC_VERSION}/${{ matrix.solc-name }}-${SOLC_VERSION}" && \
+#            chmod a+x "${PWD}/solc"
+#          echo "${PWD}" >> "${GITHUB_PATH}"
+#      - name: Build LLVM framework
+#        run: |
+#          cargo install compiler-llvm-builder --target ${{ matrix.target }}
+#          zkevm-llvm clone
+#          zkevm-llvm build
+#      - name: Build zksolc
+#        run: |
+#          cargo build -vv --release --target ${{ matrix.target }}
+#          echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
+#      - name: Run unit tests
+#        run: |
+#          cargo install cargo2junit
+#          cargo test --verbose --target ${{ matrix.target }} -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+#          cat "${UNIT_TESTS_RESULTS_XML}"
+#      - name: Upload test results
+#        if: always()
+#        uses: EnricoMi/publish-unit-test-result-action@v2
+#        with:
+#          check_name: ${{ matrix.name }} Unit Tests Results
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+#          action_fail_on_inconclusive: true
+
+#  unit-tests-windows:
+#    name: "Windows"
+#    runs-on: windows-2022-github-hosted-16core
+#    env:
+#      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
+#    defaults:
+#      run:
+#        shell: msys2 {0}
+#    steps:
+#      - name: Checkout source
+#        uses: actions/checkout@v4
+#      - name: Prepare msys2
+#        uses: msys2/setup-msys2@v2
+#      - name: Prepare env
+#        run: |
+#          pacman-key --refresh
+#          pacman -Sy
+#          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+#          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+#          pacman --noconfirm -S --needed --overwrite \
+#          base-devel \
+#          git \
+#          ninja \
+#          mingw-w64-x86_64-clang \
+#          mingw-w64-x86_64-lld \
+#          mingw-w64-x86_64-rust \
+#          mingw-w64-x86_64-gcc-libs \
+#          mingw-w64-x86_64-gcc
+#      - name: Install solc compiler
+#        run: |
+#          curl --verbose --location -o solc.exe "${SOLC_URL}/${SOLC_VERSION}/solc-windows-amd64-${SOLC_VERSION}.exe"
+#      - name: Build LLVM framework
+#        run: |
+#          cargo install compiler-llvm-builder
+#          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
+#          zkevm-llvm clone
+#          zkevm-llvm build
+#      - name: Build compiler
+#        run: |
+#          cargo build -vv --release
+#      - name: Run unit tests
+#        run: |
+#          cargo install cargo2junit
+#          export PATH="$PWD/target/release:$PWD:$PATH:/c/Users/runneradmin/.cargo/bin/"
+#          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+#          cat "${UNIT_TESTS_RESULTS_XML}"
+#      - name: Upload test results
+#        if: always()
+#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+#        with:
+#          check_name: Windows Unit Tests Results
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+#          action_fail_on_inconclusive: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -21,132 +21,130 @@ env:
   RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
 
 jobs:
-  unit-tests-macos:
-    strategy:
-      matrix:
-        include:
-          - name: "MacOS x86"
-            runner: macos-12-large
-          - name: "MacOS arm64"
-            runner: [self-hosted, macOS, ARM64]
-    runs-on: ${{ matrix.runner }}
-    name: ${{ matrix.name }}
-    defaults:
-      run:
-        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
-    env:
-      VYPER_DOWNLOAD_EXTENSION: ".darwin"
-    steps:
-      # TODO: This step should be done as part of github runners hooks
-      # Users should always expect clean workspace when a new job starts
-      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
-      - name: Cleanup workspace
-        if: ${{ matrix.name }} == "MacOS ARM64"
-        run: |
-          setopt rmstarsilent # Do not query the user before executing rm * or rm path/*.
-          setopt +o nomatch
-          rm -rf ${{ github.workspace }}/*
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Prepare environment
-        run: |
-          brew install cmake ninja
-      - name: Build LLVM framework
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 2 # protection mechanism for sporadic dependencies download failure
-          command: |
-            cargo install compiler-llvm-builder
-            zkevm-llvm clone
-            zkevm-llvm build
-      - name: Install vyper compiler
-        run: |
-          curl --location -o "${PWD}/vyper" \
-            "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}"
-          chmod a+x "${PWD}/vyper"
-          echo "${PWD}" >> "${GITHUB_PATH}"
-      - name: Build zkvyper
-        run: |
-          cargo build --release
-          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
-      - name: Install junit converter
-        run: cargo install cargo2junit
-      - name: Run unit tests
-        run: |
-          cargo test --verbose -- -Z unstable-options --format json | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
-      - name: Upload test results
-        if: always()
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-        with:
-          check_name: ${{ matrix.name }} Unit Tests Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-          action_fail_on_inconclusive: true
-
-  unit-tests-linux:
-    strategy:
-      matrix:
-        include:
-          - name: "Linux x86"
-            runner: matterlabs-ci-runner
-            target: "x86_64-unknown-linux-musl"
-#          TODO: uncomment and parametrize VYPER_DOWNLOAD_EXTENSION when arm64 linux vyper executable is available
-#          Linux ARM64 is not supported yet due to lack of Vyper executable for Linux arm64
-#          - name: "Linux arm64"
-#            runner: matterlabs-ci-runner-arm
-#            target: "aarch64-unknown-linux-musl"
-#            rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
-    runs-on: ${{ matrix.runner }}
-    name: ${{ matrix.name }}
-    container:
-      image: matterlabs/llvm_runner_jammy:latest
-      credentials:
-        username: ${{ secrets.DOCKERHUB_USER }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-    env:
-      RUSTFLAGS: ${{ matrix.rustflags }}
-      VYPER_DOWNLOAD_EXTENSION: ".linux"
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Prepare environment
-        run: |
-          rustup target add ${{ matrix.target }}
-      - name: Install vyper compiler
-        run: |
-          curl --location -o "${PWD}/vyper" \
-            "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}"
-          chmod a+x "${PWD}/vyper"
-          echo "${PWD}" >> "${GITHUB_PATH}"
-      - name: Clone LLVM framework
-        run: |
-          cargo install compiler-llvm-builder --target ${{ matrix.target }}
-          zkevm-llvm clone
-      - name: Build LLVM framework
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 2 # protection mechanism for sporadic dependencies download failure
-          command: zkevm-llvm build
-      - name: Build zkvyper
-        run: |
-          cargo build --release --target ${{ matrix.target }}
-          echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
-      - name: Install junit converter
-        run: cargo install cargo2junit
-      - name: Run unit tests
-        run: |
-          cargo test --verbose --target ${{ matrix.target }} -- -Z unstable-options --format json | \
-            cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
-      - name: Upload test results
-        if: always()
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        with:
-          check_name: ${{ matrix.name }} Unit Tests Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-          action_fail_on_inconclusive: true
+#  unit-tests-macos:
+#    strategy:
+#      matrix:
+#        include:
+#          - name: "MacOS x86"
+#            runner: macos-12-large
+#          - name: "MacOS arm64"
+#            runner: [self-hosted, macOS, ARM64]
+#    runs-on: ${{ matrix.runner }}
+#    name: ${{ matrix.name }}
+#    defaults:
+#      run:
+#        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
+#    env:
+#      VYPER_DOWNLOAD_EXTENSION: ".darwin"
+#    steps:
+#      # TODO: This step should be done as part of github runners hooks
+#      # Users should always expect clean workspace when a new job starts
+#      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
+#      - name: Cleanup workspace
+#        if: ${{ matrix.name }} == "MacOS ARM64"
+#        run: |
+#          setopt rmstarsilent # Do not query the user before executing rm * or rm path/*.
+#          setopt +o nomatch
+#          rm -rf ${{ github.workspace }}/*
+#      - name: Checkout source
+#        uses: actions/checkout@v4
+#      - name: Prepare environment
+#        run: |
+#          brew install cmake ninja
+#      - name: Clone LLVM framework
+#        run: |
+#          cargo install compiler-llvm-builder
+#          zkevm-llvm clone
+#      - name: Build LLVM framework
+#        run: |
+#          zkevm-llvm build
+#      - name: Install vyper compiler
+#        run: |
+#          curl --location -o "${PWD}/vyper" \
+#            "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}"
+#          chmod a+x "${PWD}/vyper"
+#          echo "${PWD}" >> "${GITHUB_PATH}"
+#      - name: Build zkvyper
+#        run: |
+#          cargo build --release
+#          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
+#      - name: Install junit converter
+#        run: cargo install cargo2junit
+#      - name: Run unit tests
+#        run: |
+#          cargo test --verbose -- -Z unstable-options --format json | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
+#      - name: Upload test results
+#        if: always()
+#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+#        with:
+#          check_name: ${{ matrix.name }} Unit Tests Results
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+#          action_fail_on_inconclusive: true
+#
+#  unit-tests-linux:
+#    strategy:
+#      matrix:
+#        include:
+#          - name: "Linux x86"
+#            runner: matterlabs-ci-runner
+#            target: "x86_64-unknown-linux-musl"
+##          TODO: uncomment and parametrize VYPER_DOWNLOAD_EXTENSION when arm64 linux vyper executable is available
+##          Linux ARM64 is not supported yet due to lack of Vyper executable for Linux arm64
+##          - name: "Linux arm64"
+##            runner: matterlabs-ci-runner-arm
+##            target: "aarch64-unknown-linux-musl"
+##            rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
+#    runs-on: ${{ matrix.runner }}
+#    name: ${{ matrix.name }}
+#    container:
+#      image: matterlabs/llvm_runner_jammy:latest
+#      credentials:
+#        username: ${{ secrets.DOCKERHUB_USER }}
+#        password: ${{ secrets.DOCKERHUB_TOKEN }}
+#    env:
+#      RUSTFLAGS: ${{ matrix.rustflags }}
+#      VYPER_DOWNLOAD_EXTENSION: ".linux"
+#    steps:
+#      - name: Checkout source
+#        uses: actions/checkout@v4
+#      - name: Prepare environment
+#        run: |
+#          rustup target add ${{ matrix.target }}
+#      - name: Install vyper compiler
+#        run: |
+#          curl --location -o "${PWD}/vyper" \
+#            "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}"
+#          chmod a+x "${PWD}/vyper"
+#          echo "${PWD}" >> "${GITHUB_PATH}"
+#      - name: Clone LLVM framework
+#        run: |
+#          cargo install compiler-llvm-builder --target ${{ matrix.target }}
+#          zkevm-llvm clone
+#      - name: Build LLVM framework
+#        uses: nick-fields/retry@v2
+#        with:
+#          timeout_minutes: 60
+#          max_attempts: 2 # protection mechanism for sporadic dependencies download failure
+#          command: zkevm-llvm build
+#      - name: Build zkvyper
+#        run: |
+#          cargo build --release --target ${{ matrix.target }}
+#          echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
+#      - name: Install junit converter
+#        run: cargo install cargo2junit
+#      - name: Run unit tests
+#        run: |
+#          cargo test --verbose --target ${{ matrix.target }} -- -Z unstable-options --format json | \
+#            cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
+#      - name: Upload test results
+#        if: always()
+#        uses: EnricoMi/publish-unit-test-result-action@v2
+#        with:
+#          check_name: ${{ matrix.name }} Unit Tests Results
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+#          action_fail_on_inconclusive: true
 
   unit-tests-windows:
     name: "Windows"
@@ -168,8 +166,9 @@ jobs:
         run: |
           pacman-key --refresh
           pacman -Sy
-          curl --location -o "${MINGW64_DOWNLOAD_URL}/${MINGW64_DOWNLOAD_FILENAME}"
-          pacman --noconfirm -U "${MINGW64_DOWNLOAD_FILENAME}"
+          echo ${MINGW64_DOWNLOAD_URL}/${MINGW64_DOWNLOAD_FILENAME}
+          curl --location -o ${MINGW64_DOWNLOAD_URL}/${MINGW64_DOWNLOAD_FILENAME}
+          pacman --noconfirm -U ${MINGW64_DOWNLOAD_FILENAME}
           pacman --noconfirm -S --needed --overwrite \
             base-devel \
             git \

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -113,6 +113,7 @@ jobs:
       - name: Build LLVM framework
         uses: nick-fields/retry@v2
         with:
+          timeout_minutes: 60
           max_attempts: 2
           command: |
             cargo install compiler-llvm-builder --target ${{ matrix.target }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -63,8 +63,7 @@ jobs:
           command: zkevm-llvm build
       - name: Install vyper compiler
         run: |
-          curl --verbose \
-            --location -o "${PWD}/vyper" \
+          curl --location -o "${PWD}/vyper" \
             "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}"
           chmod a+x "${PWD}/vyper"
           echo "${PWD}" >> "${GITHUB_PATH}"
@@ -117,8 +116,7 @@ jobs:
           rustup target add ${{ matrix.target }}
       - name: Install vyper compiler
         run: |
-          curl \
-            --location -o "${PWD}/vyper" \
+          curl --location -o "${PWD}/vyper" \
             "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}"
           chmod a+x "${PWD}/vyper"
           echo "${PWD}" >> "${GITHUB_PATH}"
@@ -171,8 +169,8 @@ jobs:
         run: |
           pacman-key --refresh
           pacman -Sy
-          curl -LO "${MINGW64_DOWNLOAD_LINK}/${MINGW64_DOWNLOAD_FILENAME}"
-          pacman --noconfirm -U "${MINGW64_DOWNLOAD_FILENAME}"
+          curl --location -o "${MINGW64_DOWNLOAD_LINK}/${MINGW64_DOWNLOAD_FILENAME}"
+          pacman --noconfirm -U ${MINGW64_DOWNLOAD_FILENAME}
           pacman --noconfirm -S --needed --overwrite \
             base-devel \
             git \
@@ -184,7 +182,7 @@ jobs:
             mingw-w64-x86_64-gcc
       - name: Install vyper compiler
         run: |
-          curl --verbose --location -o vyper.exe \
+          curl --location -o vyper.exe \
             "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}"
       - name: Build LLVM framework
         run: |

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -19,63 +19,63 @@ env:
   RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
 
 jobs:
-  unit-tests-macos:
-    strategy:
-      matrix:
-        include:
-          - name: "MacOS x86"
-            runner: macos-12-large
-          - name: "MacOS arm64"
-            runner: [self-hosted, macOS, ARM64]
-    runs-on: ${{ matrix.runner }}
-    name: ${{ matrix.name }}
-    defaults:
-      run:
-        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
-    env:
-      VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694.darwin"
-    steps:
-      # TODO: This step should be done as part of github runners hooks
-      # Users should always expect clean workspace when a new job starts
-      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
-      - name: Cleanup workspace
-        if: ${{ matrix.name }} == "MacOS ARM64"
-        run: |
-          setopt rmstarsilent
-          setopt +o nomatch
-          rm -rf ${{ github.workspace }}/*
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Prepare environment
-        run: |
-          brew install cmake ninja
-      - name: Build LLVM framework
-        run: |
-          cargo install compiler-llvm-builder
-          zkevm-llvm clone
-          zkevm-llvm build
-      - name: Install vyper compiler
-        run: |
-          curl --verbose \
-            --location -o "${PWD}/vyper" "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}" && \
-            chmod a+x "${PWD}/vyper"
-          echo "${PWD}" >> "${GITHUB_PATH}"
-      - name: Build zkvyper
-        run: |
-          cargo build -vv --release
-          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
-      - name: Run unit tests
-        run: |
-          cargo install cargo2junit
-          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-      - name: Upload test results
-        if: always()
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-        with:
-          check_name: ${{ matrix.name }} Unit Tests Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-          action_fail_on_inconclusive: true
+#  unit-tests-macos:
+#    strategy:
+#      matrix:
+#        include:
+#          - name: "MacOS x86"
+#            runner: macos-12-large
+#          - name: "MacOS arm64"
+#            runner: [self-hosted, macOS, ARM64]
+#    runs-on: ${{ matrix.runner }}
+#    name: ${{ matrix.name }}
+#    defaults:
+#      run:
+#        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
+#    env:
+#      VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694.darwin"
+#    steps:
+#      # TODO: This step should be done as part of github runners hooks
+#      # Users should always expect clean workspace when a new job starts
+#      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
+#      - name: Cleanup workspace
+#        if: ${{ matrix.name }} == "MacOS ARM64"
+#        run: |
+#          setopt rmstarsilent
+#          setopt +o nomatch
+#          rm -rf ${{ github.workspace }}/*
+#      - name: Checkout source
+#        uses: actions/checkout@v4
+#      - name: Prepare environment
+#        run: |
+#          brew install cmake ninja
+#      - name: Build LLVM framework
+#        run: |
+#          cargo install compiler-llvm-builder
+#          zkevm-llvm clone
+#          zkevm-llvm build
+#      - name: Install vyper compiler
+#        run: |
+#          curl --verbose \
+#            --location -o "${PWD}/vyper" "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}" && \
+#            chmod a+x "${PWD}/vyper"
+#          echo "${PWD}" >> "${GITHUB_PATH}"
+#      - name: Build zkvyper
+#        run: |
+#          cargo build -vv --release
+#          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
+#      - name: Run unit tests
+#        run: |
+#          cargo install cargo2junit
+#          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+#      - name: Upload test results
+#        if: always()
+#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+#        with:
+#          check_name: ${{ matrix.name }} Unit Tests Results
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+#          action_fail_on_inconclusive: true
 
   unit-tests-linux:
     strategy:
@@ -84,10 +84,10 @@ jobs:
           - name: "Linux x86"
             runner: matterlabs-ci-runner
             target: "x86_64-unknown-linux-musl"
-          - name: "Linux arm64"
-            runner: matterlabs-ci-runner-arm
-            target: "aarch64-unknown-linux-musl"
-            rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
+#          - name: "Linux arm64"
+#            runner: matterlabs-ci-runner-arm
+#            target: "aarch64-unknown-linux-musl"
+#            rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.name }}
     container:
@@ -111,10 +111,13 @@ jobs:
             chmod a+x "${PWD}/vyper"
           echo "${PWD}" >> "${GITHUB_PATH}"
       - name: Build LLVM framework
-        run: |
-          cargo install compiler-llvm-builder --target ${{ matrix.target }}
-          zkevm-llvm clone
-          zkevm-llvm build
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 2
+          command: |
+            cargo install compiler-llvm-builder --target ${{ matrix.target }}
+            zkevm-llvm clone
+            zkevm-llvm build
       - name: Build zkvyper
         run: |
           cargo build -vv --release --target ${{ matrix.target }}
@@ -133,58 +136,58 @@ jobs:
           files: ${{ env.UNIT_TESTS_RESULTS_XML }}
           action_fail_on_inconclusive: true
 
-  unit-tests-windows:
-    name: "Windows"
-    runs-on: windows-2022-github-hosted-16core
-    env:
-      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
-      VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694.windows.exe"
-    defaults:
-      run:
-        shell: msys2 {0}
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Prepare msys2
-        uses: msys2/setup-msys2@v2
-      - name: Prepare env
-        run: |
-          pacman-key --refresh
-          pacman -Sy
-          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-          pacman --noconfirm -S --needed --overwrite \
-          base-devel \
-          git \
-          ninja \
-          mingw-w64-x86_64-clang \
-          mingw-w64-x86_64-lld \
-          mingw-w64-x86_64-rust \
-          mingw-w64-x86_64-gcc-libs \
-          mingw-w64-x86_64-gcc
-      - name: Install vyper compiler
-        run: |
-          curl --verbose --location -o vyper.exe "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}"
-      - name: Build LLVM framework
-        run: |
-          cargo install compiler-llvm-builder
-          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
-          zkevm-llvm clone
-          zkevm-llvm build
-      - name: Build compiler
-        run: |
-          cargo build -vv --release
-      - name: Run unit tests
-        run: |
-          cargo install cargo2junit
-          export PATH="$PWD/target/release:$PWD:$PATH:/c/Users/runneradmin/.cargo/bin/"
-          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-          cat "${UNIT_TESTS_RESULTS_XML}"
-      - name: Upload test results
-        if: always()
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-        with:
-          check_name: Windows Unit Tests Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-          action_fail_on_inconclusive: true
+#  unit-tests-windows:
+#    name: "Windows"
+#    runs-on: windows-2022-github-hosted-16core
+#    env:
+#      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
+#      VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694.windows.exe"
+#    defaults:
+#      run:
+#        shell: msys2 {0}
+#    steps:
+#      - name: Checkout source
+#        uses: actions/checkout@v4
+#      - name: Prepare msys2
+#        uses: msys2/setup-msys2@v2
+#      - name: Prepare env
+#        run: |
+#          pacman-key --refresh
+#          pacman -Sy
+#          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+#          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+#          pacman --noconfirm -S --needed --overwrite \
+#          base-devel \
+#          git \
+#          ninja \
+#          mingw-w64-x86_64-clang \
+#          mingw-w64-x86_64-lld \
+#          mingw-w64-x86_64-rust \
+#          mingw-w64-x86_64-gcc-libs \
+#          mingw-w64-x86_64-gcc
+#      - name: Install vyper compiler
+#        run: |
+#          curl --verbose --location -o vyper.exe "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}"
+#      - name: Build LLVM framework
+#        run: |
+#          cargo install compiler-llvm-builder
+#          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
+#          zkevm-llvm clone
+#          zkevm-llvm build
+#      - name: Build compiler
+#        run: |
+#          cargo build -vv --release
+#      - name: Run unit tests
+#        run: |
+#          cargo install cargo2junit
+#          export PATH="$PWD/target/release:$PWD:$PATH:/c/Users/runneradmin/.cargo/bin/"
+#          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+#          cat "${UNIT_TESTS_RESULTS_XML}"
+#      - name: Upload test results
+#        if: always()
+#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+#        with:
+#          check_name: Windows Unit Tests Results
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+#          action_fail_on_inconclusive: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -19,63 +19,63 @@ env:
   RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
 
 jobs:
-  unit-tests-macos:
-    strategy:
-      matrix:
-        include:
-          - name: "MacOS x86"
-            runner: macos-12-large
-          - name: "MacOS arm64"
-            runner: [self-hosted, macOS, ARM64]
-    runs-on: ${{ matrix.runner }}
-    name: ${{ matrix.name }}
-    defaults:
-      run:
-        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
-    env:
-      VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694.darwin"
-    steps:
-      # TODO: This step should be done as part of github runners hooks
-      # Users should always expect clean workspace when a new job starts
-      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
-      - name: Cleanup workspace
-        if: ${{ matrix.name }} == "MacOS ARM64"
-        run: |
-          setopt rmstarsilent
-          setopt +o nomatch
-          rm -rf ${{ github.workspace }}/*
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Prepare environment
-        run: |
-          brew install cmake ninja
-      - name: Build LLVM framework
-        run: |
-          cargo install compiler-llvm-builder
-          zkevm-llvm clone
-          zkevm-llvm build
-      - name: Install vyper compiler
-        run: |
-          curl --verbose \
-            --location -o "${PWD}/vyper" "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}" && \
-            chmod a+x "${PWD}/vyper"
-          echo "${PWD}" >> "${GITHUB_PATH}"
-      - name: Build zkvyper
-        run: |
-          cargo build -vv --release
-          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
-      - name: Run unit tests
-        run: |
-          cargo install cargo2junit
-          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-      - name: Upload test results
-        if: always()
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-        with:
-          check_name: ${{ matrix.name }} Unit Tests Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-          action_fail_on_inconclusive: true
+#  unit-tests-macos:
+#    strategy:
+#      matrix:
+#        include:
+#          - name: "MacOS x86"
+#            runner: macos-12-large
+#          - name: "MacOS arm64"
+#            runner: [self-hosted, macOS, ARM64]
+#    runs-on: ${{ matrix.runner }}
+#    name: ${{ matrix.name }}
+#    defaults:
+#      run:
+#        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
+#    env:
+#      VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694.darwin"
+#    steps:
+#      # TODO: This step should be done as part of github runners hooks
+#      # Users should always expect clean workspace when a new job starts
+#      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
+#      - name: Cleanup workspace
+#        if: ${{ matrix.name }} == "MacOS ARM64"
+#        run: |
+#          setopt rmstarsilent
+#          setopt +o nomatch
+#          rm -rf ${{ github.workspace }}/*
+#      - name: Checkout source
+#        uses: actions/checkout@v4
+#      - name: Prepare environment
+#        run: |
+#          brew install cmake ninja
+#      - name: Build LLVM framework
+#        run: |
+#          cargo install compiler-llvm-builder
+#          zkevm-llvm clone
+#          zkevm-llvm build
+#      - name: Install vyper compiler
+#        run: |
+#          curl --verbose \
+#            --location -o "${PWD}/vyper" "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}" && \
+#            chmod a+x "${PWD}/vyper"
+#          echo "${PWD}" >> "${GITHUB_PATH}"
+#      - name: Build zkvyper
+#        run: |
+#          cargo build -vv --release
+#          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
+#      - name: Run unit tests
+#        run: |
+#          cargo install cargo2junit
+#          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+#      - name: Upload test results
+#        if: always()
+#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+#        with:
+#          check_name: ${{ matrix.name }} Unit Tests Results
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+#          action_fail_on_inconclusive: true
 
   unit-tests-linux:
     strategy:
@@ -121,7 +121,12 @@ jobs:
           echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
       - name: Run unit tests
         run: |
+          set -x
           cargo install cargo2junit
+          which vyper
+          which zkvyper
+          vyper --version
+          zkvyper --version
           cargo test --verbose --target ${{ matrix.target }} -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
           cat "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
@@ -133,58 +138,58 @@ jobs:
           files: ${{ env.UNIT_TESTS_RESULTS_XML }}
           action_fail_on_inconclusive: true
 
-  unit-tests-windows:
-    name: "Windows"
-    runs-on: windows-2022-github-hosted-16core
-    env:
-      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
-      VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694.windows.exe"
-    defaults:
-      run:
-        shell: msys2 {0}
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Prepare msys2
-        uses: msys2/setup-msys2@v2
-      - name: Prepare env
-        run: |
-          pacman-key --refresh
-          pacman -Sy
-          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-          pacman --noconfirm -S --needed --overwrite \
-          base-devel \
-          git \
-          ninja \
-          mingw-w64-x86_64-clang \
-          mingw-w64-x86_64-lld \
-          mingw-w64-x86_64-rust \
-          mingw-w64-x86_64-gcc-libs \
-          mingw-w64-x86_64-gcc
-      - name: Install vyper compiler
-        run: |
-          curl --verbose --location -o vyper.exe "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}"
-      - name: Build LLVM framework
-        run: |
-          cargo install compiler-llvm-builder
-          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
-          zkevm-llvm clone
-          zkevm-llvm build
-      - name: Build compiler
-        run: |
-          cargo build -vv --release
-      - name: Run unit tests
-        run: |
-          cargo install cargo2junit
-          export PATH="$PWD/target/release:$PWD:$PATH:/c/Users/runneradmin/.cargo/bin/"
-          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-          cat "${UNIT_TESTS_RESULTS_XML}"
-      - name: Upload test results
-        if: always()
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-        with:
-          check_name: Windows Unit Tests Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-          action_fail_on_inconclusive: true
+#  unit-tests-windows:
+#    name: "Windows"
+#    runs-on: windows-2022-github-hosted-16core
+#    env:
+#      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
+#      VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694.windows.exe"
+#    defaults:
+#      run:
+#        shell: msys2 {0}
+#    steps:
+#      - name: Checkout source
+#        uses: actions/checkout@v4
+#      - name: Prepare msys2
+#        uses: msys2/setup-msys2@v2
+#      - name: Prepare env
+#        run: |
+#          pacman-key --refresh
+#          pacman -Sy
+#          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+#          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+#          pacman --noconfirm -S --needed --overwrite \
+#          base-devel \
+#          git \
+#          ninja \
+#          mingw-w64-x86_64-clang \
+#          mingw-w64-x86_64-lld \
+#          mingw-w64-x86_64-rust \
+#          mingw-w64-x86_64-gcc-libs \
+#          mingw-w64-x86_64-gcc
+#      - name: Install vyper compiler
+#        run: |
+#          curl --verbose --location -o vyper.exe "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}"
+#      - name: Build LLVM framework
+#        run: |
+#          cargo install compiler-llvm-builder
+#          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
+#          zkevm-llvm clone
+#          zkevm-llvm build
+#      - name: Build compiler
+#        run: |
+#          cargo build -vv --release
+#      - name: Run unit tests
+#        run: |
+#          cargo install cargo2junit
+#          export PATH="$PWD/target/release:$PWD:$PATH:/c/Users/runneradmin/.cargo/bin/"
+#          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+#          cat "${UNIT_TESTS_RESULTS_XML}"
+#      - name: Upload test results
+#        if: always()
+#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+#        with:
+#          check_name: Windows Unit Tests Results
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+#          action_fail_on_inconclusive: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,70 +12,72 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false # for now, false (put jobs in queue) allowing multiple PR testing consequently
 env:
-  VYPER_VERSION: "v0.3.10"
   VYPER_DOWNLOAD_URL: "https://github.com/vyperlang/vyper/releases/download"
+  VYPER_VERSION: "v0.3.10"
+  VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694"
   CARGO_NET_GIT_FETCH_WITH_CLI: true
   UNIT_TESTS_RESULTS_XML: unit-tests-results.xml
   RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
 
 jobs:
-#  unit-tests-macos:
-#    strategy:
-#      matrix:
-#        include:
-#          - name: "MacOS x86"
-#            runner: macos-12-large
-#          - name: "MacOS arm64"
-#            runner: [self-hosted, macOS, ARM64]
-#    runs-on: ${{ matrix.runner }}
-#    name: ${{ matrix.name }}
-#    defaults:
-#      run:
-#        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
-#    env:
-#      VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694.darwin"
-#    steps:
-#      # TODO: This step should be done as part of github runners hooks
-#      # Users should always expect clean workspace when a new job starts
-#      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
-#      - name: Cleanup workspace
-#        if: ${{ matrix.name }} == "MacOS ARM64"
-#        run: |
-#          setopt rmstarsilent
-#          setopt +o nomatch
-#          rm -rf ${{ github.workspace }}/*
-#      - name: Checkout source
-#        uses: actions/checkout@v4
-#      - name: Prepare environment
-#        run: |
-#          brew install cmake ninja
-#      - name: Build LLVM framework
-#        run: |
-#          cargo install compiler-llvm-builder
-#          zkevm-llvm clone
-#          zkevm-llvm build
-#      - name: Install vyper compiler
-#        run: |
-#          curl --verbose \
-#            --location -o "${PWD}/vyper" "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}" && \
-#            chmod a+x "${PWD}/vyper"
-#          echo "${PWD}" >> "${GITHUB_PATH}"
-#      - name: Build zkvyper
-#        run: |
-#          cargo build -vv --release
-#          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
-#      - name: Run unit tests
-#        run: |
-#          cargo install cargo2junit
-#          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-#      - name: Upload test results
-#        if: always()
-#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-#        with:
-#          check_name: ${{ matrix.name }} Unit Tests Results
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-#          action_fail_on_inconclusive: true
+  unit-tests-macos:
+    strategy:
+      matrix:
+        include:
+          - name: "MacOS x86"
+            runner: macos-12-large
+          - name: "MacOS arm64"
+            runner: [self-hosted, macOS, ARM64]
+    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.name }}
+    defaults:
+      run:
+        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
+    env:
+      VYPER_DOWNLOAD_EXTENSION: ".darwin"
+    steps:
+      # TODO: This step should be done as part of github runners hooks
+      # Users should always expect clean workspace when a new job starts
+      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
+      - name: Cleanup workspace
+        if: ${{ matrix.name }} == "MacOS ARM64"
+        run: |
+          setopt rmstarsilent
+          setopt +o nomatch
+          rm -rf ${{ github.workspace }}/*
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Prepare environment
+        run: |
+          brew install cmake ninja
+      - name: Build LLVM framework
+        run: |
+          cargo install compiler-llvm-builder
+          zkevm-llvm clone
+          zkevm-llvm build
+      - name: Install vyper compiler
+        run: |
+          curl --verbose \
+            --location -o "${PWD}/vyper" \
+            "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}" && \
+            chmod a+x "${PWD}/vyper"
+          echo "${PWD}" >> "${GITHUB_PATH}"
+      - name: Build zkvyper
+        run: |
+          cargo build -vv --release
+          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
+      - name: Run unit tests
+        run: |
+          cargo install cargo2junit
+          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+      - name: Upload test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        with:
+          check_name: ${{ matrix.name }} Unit Tests Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+          action_fail_on_inconclusive: true
 
   unit-tests-linux:
     strategy:
@@ -84,10 +86,10 @@ jobs:
           - name: "Linux x86"
             runner: matterlabs-ci-runner
             target: "x86_64-unknown-linux-musl"
-#          - name: "Linux arm64"
-#            runner: matterlabs-ci-runner-arm
-#            target: "aarch64-unknown-linux-musl"
-#            rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
+          - name: "Linux arm64"
+            runner: matterlabs-ci-runner-arm
+            target: "aarch64-unknown-linux-musl"
+            rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.name }}
     container:
@@ -97,7 +99,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     env:
       RUSTFLAGS: ${{ matrix.rustflags }}
-      VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694.linux"
+      VYPER_DOWNLOAD_EXTENSION: ".linux"
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -107,18 +109,20 @@ jobs:
       - name: Install vyper compiler
         run: |
           curl --verbose \
-            --location -o "${PWD}/vyper" "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}" && \
+            --location -o "${PWD}/vyper" \
+            "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}" && \
             chmod a+x "${PWD}/vyper"
           echo "${PWD}" >> "${GITHUB_PATH}"
+      - name: Clone LLVM framework
+        run: |
+          cargo install compiler-llvm-builder --target ${{ matrix.target }}
+          zkevm-llvm clone
       - name: Build LLVM framework
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 60
-          max_attempts: 2
-          command: |
-            cargo install compiler-llvm-builder --target ${{ matrix.target }}
-            zkevm-llvm clone
-            zkevm-llvm build
+          max_attempts: 2 # protection mechanism for MUSL sporadic download failure
+          command: zkevm-llvm build
       - name: Build zkvyper
         run: |
           cargo build -vv --release --target ${{ matrix.target }}
@@ -137,58 +141,59 @@ jobs:
           files: ${{ env.UNIT_TESTS_RESULTS_XML }}
           action_fail_on_inconclusive: true
 
-#  unit-tests-windows:
-#    name: "Windows"
-#    runs-on: windows-2022-github-hosted-16core
-#    env:
-#      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
-#      VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694.windows.exe"
-#    defaults:
-#      run:
-#        shell: msys2 {0}
-#    steps:
-#      - name: Checkout source
-#        uses: actions/checkout@v4
-#      - name: Prepare msys2
-#        uses: msys2/setup-msys2@v2
-#      - name: Prepare env
-#        run: |
-#          pacman-key --refresh
-#          pacman -Sy
-#          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-#          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-#          pacman --noconfirm -S --needed --overwrite \
-#          base-devel \
-#          git \
-#          ninja \
-#          mingw-w64-x86_64-clang \
-#          mingw-w64-x86_64-lld \
-#          mingw-w64-x86_64-rust \
-#          mingw-w64-x86_64-gcc-libs \
-#          mingw-w64-x86_64-gcc
-#      - name: Install vyper compiler
-#        run: |
-#          curl --verbose --location -o vyper.exe "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}"
-#      - name: Build LLVM framework
-#        run: |
-#          cargo install compiler-llvm-builder
-#          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
-#          zkevm-llvm clone
-#          zkevm-llvm build
-#      - name: Build compiler
-#        run: |
-#          cargo build -vv --release
-#      - name: Run unit tests
-#        run: |
-#          cargo install cargo2junit
-#          export PATH="$PWD/target/release:$PWD:$PATH:/c/Users/runneradmin/.cargo/bin/"
-#          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-#          cat "${UNIT_TESTS_RESULTS_XML}"
-#      - name: Upload test results
-#        if: always()
-#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-#        with:
-#          check_name: Windows Unit Tests Results
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-#          action_fail_on_inconclusive: true
+  unit-tests-windows:
+    name: "Windows"
+    runs-on: windows-2022-github-hosted-16core
+    env:
+      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
+      VYPER_DOWNLOAD_EXTENSION: ".windows.exe"
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Prepare msys2
+        uses: msys2/setup-msys2@v2
+      - name: Prepare env
+        run: |
+          pacman-key --refresh
+          pacman -Sy
+          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+          pacman --noconfirm -S --needed --overwrite \
+          base-devel \
+          git \
+          ninja \
+          mingw-w64-x86_64-clang \
+          mingw-w64-x86_64-lld \
+          mingw-w64-x86_64-rust \
+          mingw-w64-x86_64-gcc-libs \
+          mingw-w64-x86_64-gcc
+      - name: Install vyper compiler
+        run: |
+          curl --verbose --location -o vyper.exe \
+            "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}"
+      - name: Build LLVM framework
+        run: |
+          cargo install compiler-llvm-builder
+          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
+          zkevm-llvm clone
+          zkevm-llvm build
+      - name: Build compiler
+        run: |
+          cargo build -vv --release
+      - name: Run unit tests
+        run: |
+          cargo install cargo2junit
+          export PATH="$PWD/target/release:$PWD:$PATH:/c/Users/runneradmin/.cargo/bin/"
+          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+          cat "${UNIT_TESTS_RESULTS_XML}"
+      - name: Upload test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        with:
+          check_name: Windows Unit Tests Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+          action_fail_on_inconclusive: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -2,6 +2,7 @@ name: Unit Tests
 
 # Execute workflow for each PR and with each merge to the trunk
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:
@@ -42,7 +43,7 @@ jobs:
       - name: Cleanup workspace
         if: ${{ matrix.name }} == "MacOS ARM64"
         run: |
-          setopt rmstarsilent
+          setopt rmstarsilent # Do not query the user before executing rm * or rm path/*.
           setopt +o nomatch
           rm -rf ${{ github.workspace }}/*
       - name: Checkout source
@@ -50,26 +51,32 @@ jobs:
       - name: Prepare environment
         run: |
           brew install cmake ninja
-      - name: Build LLVM framework
+      - name: Clone LLVM framework
         run: |
           cargo install compiler-llvm-builder
           zkevm-llvm clone
-          zkevm-llvm build
+      - name: Build LLVM framework
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 2 # protection mechanism for sporadic dependencies download failure
+          command: zkevm-llvm build
       - name: Install vyper compiler
         run: |
           curl --verbose \
             --location -o "${PWD}/vyper" \
-            "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}" && \
-            chmod a+x "${PWD}/vyper"
+            "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}"
+          chmod a+x "${PWD}/vyper"
           echo "${PWD}" >> "${GITHUB_PATH}"
       - name: Build zkvyper
         run: |
-          cargo build -vv --release
+          cargo build --release
           echo "${PWD}/target/release" >> "${GITHUB_PATH}"
+      - name: Install junit converter
+        run: cargo install cargo2junit
       - name: Run unit tests
         run: |
-          cargo install cargo2junit
-          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+          cargo test --verbose -- -Z unstable-options --format json | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
         if: always()
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
@@ -86,6 +93,7 @@ jobs:
           - name: "Linux x86"
             runner: matterlabs-ci-runner
             target: "x86_64-unknown-linux-musl"
+#          TODO: uncomment and parametrize VYPER_DOWNLOAD_EXTENSION when arm64 linux vyper executable is available
 #          Linux ARM64 is not supported yet due to lack of Vyper executable for Linux arm64
 #          - name: "Linux arm64"
 #            runner: matterlabs-ci-runner-arm
@@ -109,10 +117,10 @@ jobs:
           rustup target add ${{ matrix.target }}
       - name: Install vyper compiler
         run: |
-          curl --verbose \
+          curl \
             --location -o "${PWD}/vyper" \
-            "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}" && \
-            chmod a+x "${PWD}/vyper"
+            "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}"
+          chmod a+x "${PWD}/vyper"
           echo "${PWD}" >> "${GITHUB_PATH}"
       - name: Clone LLVM framework
         run: |
@@ -122,17 +130,18 @@ jobs:
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 60
-          max_attempts: 2 # protection mechanism for MUSL sporadic download failure
+          max_attempts: 2 # protection mechanism for sporadic dependencies download failure
           command: zkevm-llvm build
       - name: Build zkvyper
         run: |
-          cargo build -vv --release --target ${{ matrix.target }}
+          cargo build --release --target ${{ matrix.target }}
           echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
+      - name: Install junit converter
+        run: cargo install cargo2junit
       - name: Run unit tests
         run: |
-          cargo install cargo2junit
-          cargo test --verbose --target ${{ matrix.target }} -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-          cat "${UNIT_TESTS_RESULTS_XML}"
+          cargo test --verbose --target ${{ matrix.target }} -- -Z unstable-options --format json | \
+            cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
         if: always()
         uses: EnricoMi/publish-unit-test-result-action@v2
@@ -148,6 +157,8 @@ jobs:
     env:
       LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
       VYPER_DOWNLOAD_EXTENSION: ".windows.exe"
+      MINGW64_DOWNLOAD_URL: "https://repo.msys2.org/mingw/mingw64"
+      MINGW64_DOWNLOAD_FILENAME: "mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst"
     defaults:
       run:
         shell: msys2 {0}
@@ -160,17 +171,17 @@ jobs:
         run: |
           pacman-key --refresh
           pacman -Sy
-          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+          curl -LO "${MINGW64_DOWNLOAD_LINK}/${MINGW64_DOWNLOAD_FILENAME}"
+          pacman --noconfirm -U "${MINGW64_DOWNLOAD_FILENAME}"
           pacman --noconfirm -S --needed --overwrite \
-          base-devel \
-          git \
-          ninja \
-          mingw-w64-x86_64-clang \
-          mingw-w64-x86_64-lld \
-          mingw-w64-x86_64-rust \
-          mingw-w64-x86_64-gcc-libs \
-          mingw-w64-x86_64-gcc
+            base-devel \
+            git \
+            ninja \
+            mingw-w64-x86_64-clang \
+            mingw-w64-x86_64-lld \
+            mingw-w64-x86_64-rust \
+            mingw-w64-x86_64-gcc-libs \
+            mingw-w64-x86_64-gcc
       - name: Install vyper compiler
         run: |
           curl --verbose --location -o vyper.exe \
@@ -183,13 +194,13 @@ jobs:
           zkevm-llvm build
       - name: Build compiler
         run: |
-          cargo build -vv --release
+          cargo build --release
+      - name: Install junit converter
+        run: cargo install cargo2junit
       - name: Run unit tests
         run: |
-          cargo install cargo2junit
           export PATH="$PWD/target/release:$PWD:$PATH:/c/Users/runneradmin/.cargo/bin/"
-          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-          cat "${UNIT_TESTS_RESULTS_XML}"
+          cargo test --verbose -- -Z unstable-options --format json | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
         if: always()
         uses: EnricoMi/publish-unit-test-result-action/composite@v2

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -86,10 +86,11 @@ jobs:
           - name: "Linux x86"
             runner: matterlabs-ci-runner
             target: "x86_64-unknown-linux-musl"
-          - name: "Linux arm64"
-            runner: matterlabs-ci-runner-arm
-            target: "aarch64-unknown-linux-musl"
-            rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
+#          Linux ARM64 is not supported yet due to lack of Vyper executable for Linux arm64
+#          - name: "Linux arm64"
+#            runner: matterlabs-ci-runner-arm
+#            target: "aarch64-unknown-linux-musl"
+#            rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.name }}
     container:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -19,63 +19,63 @@ env:
   RUSTC_BOOTSTRAP: 1 # Use rustc in bootstrap mode allowing cargo2junit to use experimental --json feature
 
 jobs:
-#  unit-tests-macos:
-#    strategy:
-#      matrix:
-#        include:
-#          - name: "MacOS x86"
-#            runner: macos-12-large
-#          - name: "MacOS arm64"
-#            runner: [self-hosted, macOS, ARM64]
-#    runs-on: ${{ matrix.runner }}
-#    name: ${{ matrix.name }}
-#    defaults:
-#      run:
-#        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
-#    env:
-#      VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694.darwin"
-#    steps:
-#      # TODO: This step should be done as part of github runners hooks
-#      # Users should always expect clean workspace when a new job starts
-#      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
-#      - name: Cleanup workspace
-#        if: ${{ matrix.name }} == "MacOS ARM64"
-#        run: |
-#          setopt rmstarsilent
-#          setopt +o nomatch
-#          rm -rf ${{ github.workspace }}/*
-#      - name: Checkout source
-#        uses: actions/checkout@v4
-#      - name: Prepare environment
-#        run: |
-#          brew install cmake ninja
-#      - name: Build LLVM framework
-#        run: |
-#          cargo install compiler-llvm-builder
-#          zkevm-llvm clone
-#          zkevm-llvm build
-#      - name: Install vyper compiler
-#        run: |
-#          curl --verbose \
-#            --location -o "${PWD}/vyper" "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}" && \
-#            chmod a+x "${PWD}/vyper"
-#          echo "${PWD}" >> "${GITHUB_PATH}"
-#      - name: Build zkvyper
-#        run: |
-#          cargo build -vv --release
-#          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
-#      - name: Run unit tests
-#        run: |
-#          cargo install cargo2junit
-#          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-#      - name: Upload test results
-#        if: always()
-#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-#        with:
-#          check_name: ${{ matrix.name }} Unit Tests Results
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-#          action_fail_on_inconclusive: true
+  unit-tests-macos:
+    strategy:
+      matrix:
+        include:
+          - name: "MacOS x86"
+            runner: macos-12-large
+          - name: "MacOS arm64"
+            runner: [self-hosted, macOS, ARM64]
+    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.name }}
+    defaults:
+      run:
+        shell: zsh {0} # For MacOS hosts, .zprofile is pre-configured
+    env:
+      VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694.darwin"
+    steps:
+      # TODO: This step should be done as part of github runners hooks
+      # Users should always expect clean workspace when a new job starts
+      # https://github.blog/changelog/2022-04-04-github-actions-job-management-hooks-for-self-hosted-runners/
+      - name: Cleanup workspace
+        if: ${{ matrix.name }} == "MacOS ARM64"
+        run: |
+          setopt rmstarsilent
+          setopt +o nomatch
+          rm -rf ${{ github.workspace }}/*
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Prepare environment
+        run: |
+          brew install cmake ninja
+      - name: Build LLVM framework
+        run: |
+          cargo install compiler-llvm-builder
+          zkevm-llvm clone
+          zkevm-llvm build
+      - name: Install vyper compiler
+        run: |
+          curl --verbose \
+            --location -o "${PWD}/vyper" "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}" && \
+            chmod a+x "${PWD}/vyper"
+          echo "${PWD}" >> "${GITHUB_PATH}"
+      - name: Build zkvyper
+        run: |
+          cargo build -vv --release
+          echo "${PWD}/target/release" >> "${GITHUB_PATH}"
+      - name: Run unit tests
+        run: |
+          cargo install cargo2junit
+          cargo test -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+      - name: Upload test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        with:
+          check_name: ${{ matrix.name }} Unit Tests Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+          action_fail_on_inconclusive: true
 
   unit-tests-linux:
     strategy:
@@ -121,12 +121,7 @@ jobs:
           echo "${PWD}/target/${{ matrix.target }}/release" >> "${GITHUB_PATH}"
       - name: Run unit tests
         run: |
-          set -x
           cargo install cargo2junit
-          which vyper
-          which zkvyper
-          vyper --version
-          zkvyper --version
           cargo test --verbose --target ${{ matrix.target }} -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
           cat "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
@@ -138,58 +133,58 @@ jobs:
           files: ${{ env.UNIT_TESTS_RESULTS_XML }}
           action_fail_on_inconclusive: true
 
-#  unit-tests-windows:
-#    name: "Windows"
-#    runs-on: windows-2022-github-hosted-16core
-#    env:
-#      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
-#      VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694.windows.exe"
-#    defaults:
-#      run:
-#        shell: msys2 {0}
-#    steps:
-#      - name: Checkout source
-#        uses: actions/checkout@v4
-#      - name: Prepare msys2
-#        uses: msys2/setup-msys2@v2
-#      - name: Prepare env
-#        run: |
-#          pacman-key --refresh
-#          pacman -Sy
-#          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-#          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-#          pacman --noconfirm -S --needed --overwrite \
-#          base-devel \
-#          git \
-#          ninja \
-#          mingw-w64-x86_64-clang \
-#          mingw-w64-x86_64-lld \
-#          mingw-w64-x86_64-rust \
-#          mingw-w64-x86_64-gcc-libs \
-#          mingw-w64-x86_64-gcc
-#      - name: Install vyper compiler
-#        run: |
-#          curl --verbose --location -o vyper.exe "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}"
-#      - name: Build LLVM framework
-#        run: |
-#          cargo install compiler-llvm-builder
-#          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
-#          zkevm-llvm clone
-#          zkevm-llvm build
-#      - name: Build compiler
-#        run: |
-#          cargo build -vv --release
-#      - name: Run unit tests
-#        run: |
-#          cargo install cargo2junit
-#          export PATH="$PWD/target/release:$PWD:$PATH:/c/Users/runneradmin/.cargo/bin/"
-#          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
-#          cat "${UNIT_TESTS_RESULTS_XML}"
-#      - name: Upload test results
-#        if: always()
-#        uses: EnricoMi/publish-unit-test-result-action/composite@v2
-#        with:
-#          check_name: Windows Unit Tests Results
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-#          action_fail_on_inconclusive: true
+  unit-tests-windows:
+    name: "Windows"
+    runs-on: windows-2022-github-hosted-16core
+    env:
+      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
+      VYPER_DOWNLOAD_FILENAME: "vyper.0.3.10+commit.91361694.windows.exe"
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Prepare msys2
+        uses: msys2/setup-msys2@v2
+      - name: Prepare env
+        run: |
+          pacman-key --refresh
+          pacman -Sy
+          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+          pacman --noconfirm -S --needed --overwrite \
+          base-devel \
+          git \
+          ninja \
+          mingw-w64-x86_64-clang \
+          mingw-w64-x86_64-lld \
+          mingw-w64-x86_64-rust \
+          mingw-w64-x86_64-gcc-libs \
+          mingw-w64-x86_64-gcc
+      - name: Install vyper compiler
+        run: |
+          curl --verbose --location -o vyper.exe "${VYPER_DOWNLOAD_URL}/${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}"
+      - name: Build LLVM framework
+        run: |
+          cargo install compiler-llvm-builder
+          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
+          zkevm-llvm clone
+          zkevm-llvm build
+      - name: Build compiler
+        run: |
+          cargo build -vv --release
+      - name: Run unit tests
+        run: |
+          cargo install cargo2junit
+          export PATH="$PWD/target/release:$PWD:$PATH:/c/Users/runneradmin/.cargo/bin/"
+          cargo test --verbose -- -Z unstable-options --format json | cargo2junit > "${UNIT_TESTS_RESULTS_XML}"
+          cat "${UNIT_TESTS_RESULTS_XML}"
+      - name: Upload test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        with:
+          check_name: Windows Unit Tests Results
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+          action_fail_on_inconclusive: true


### PR DESCRIPTION
Fixes [CPR-1273](https://linear.app/matterlabs/issue/CPR-1273/github-action-for-zkvyper-unit-tests)

Add unit tests execution in CI with each PR and merge to the trunk.

Supported targets:
* Macos x86_64
* Macos ARM64
* Linux x86_64
* Windows Mingw64

> KNOWN RESTRICTION - not supported target: `Linux ARM64` due to lack of the `vyper` executable built for Linux ARM64.

Results are reported as PR checks, e.g.:
<img width="622" alt="image" src="https://github.com/matter-labs/era-compiler-vyper/assets/22070213/9d8450e6-fb86-4159-9d0b-fd0e46812205">

As well as PR auto-updated comments:
<img width="847" alt="image" src="https://github.com/matter-labs/era-compiler-vyper/assets/22070213/7f8df015-9ad1-4f96-affc-0671f4e06469">

For now, 8 unit tests exist and all pass on all available platforms.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

In order to keep the trunk always stable, introduce unit tests quality gates on the PR level as well as make sure that unit tests in the `main` branch are always working after the merge.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
