### PR TITLE
fix: misspelled word

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -15,7 +15,7 @@ use once_cell::sync::OnceCell;
 use self::input::Input;
 use self::output::Output;
 
-/// The overriden executable name used when the compiler is run as a library.
+/// The overridden executable name used when the compiler is run as a library.
 pub static EXECUTABLE: OnceCell<PathBuf> = OnceCell::new();
 
 ///


### PR DESCRIPTION
## Why ❔

 In the sentence "The overriden executable name used when the compiler is run as a library," the word "overriden" appears to be spelled incorrectly. The correct spelling should be "overridden," indicating that something has been replaced or modified. Therefore, the corrected sentence is:

"The overridden executable name used when the compiler is run as a library."

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
