### PR TITLE
ci: update linux docker image to public ubuntu22-llvm15-latest

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -168,9 +168,6 @@ jobs:
     runs-on: [matterlabs-ci-runner]
     container:
       image: matterlabs/llvm_runner:latest
-      credentials:
-        username: ${{ secrets.DOCKERHUB_USER }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -225,10 +222,7 @@ jobs:
     if: github.event.inputs.release_linux_arm64 || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: matterlabs-ci-runner-arm
     container:
-      image: matterlabs/llvm_runner_jammy:latest
-      credentials:
-        username: ${{ secrets.DOCKERHUB_USER }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      image: matterlabs/llvm_runner:ubuntu22-llvm15-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -98,10 +98,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.name }}
     container:
-      image: matterlabs/llvm_runner_jammy:latest
-      credentials:
-        username: ${{ secrets.DOCKERHUB_USER }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      image: matterlabs/llvm_runner:ubuntu22-llvm15-latest
     env:
       RUSTFLAGS: ${{ matrix.rustflags }}
       VYPER_DOWNLOAD_EXTENSION: ".linux"


### PR DESCRIPTION
# What ❔

Update Linux docker image to `ubuntu22-llvm15-latest` from public Dockerhub registry.
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

The previous `jammy` image was private preventing forks to be properly tested.
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
