### PR TITLE
test: uncommented test with vyper exit code

### DIFF
--- a/cli-tests/tests/common.test.ts
+++ b/cli-tests/tests/common.test.ts
@@ -17,7 +17,7 @@ describe("Common tests", () => {
         it("Exit code = 1", () => {
             expect(result.exitCode).toBe(1);
         });
-        xit("vyper exit code == zkvyper exit code", () => {
+        it("vyper exit code == zkvyper exit code", () => {
             const vyperResult = executeCommand(vyperCommand, args);
             expect(vyperResult.exitCode).toBe(result.exitCode); // 2 for vyper and 1 for zkvyper
         });


### PR DESCRIPTION
# What ❔

Issue: CPR-1539/[zkvyper][info]-different-exit-code-for-zkvyper-and-vyper

## Why ❔

uncommented tests that shows the issue

## Checklist


- [ ] PR title corresponds to the body of PR.
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
