### PR TITLE
ci: restore slack notifications with new token

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -150,3 +150,26 @@ jobs:
             gh release create ${{ steps.version_or_sha.outputs.version_or_sha }} \
               --title ${{ steps.version_or_sha.outputs.version_or_sha }} \
               "${BINARIES[@]}"
+
+      - name: Get changelog
+        if: github.ref_type == 'tag'
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          validation_level: warn
+          path: ./CHANGELOG.md
+
+      - name: Prepare CHANGELOG for publishing
+        if: github.ref_type == 'tag'
+        run: |
+          echo "## ${{ github.event.repository.name }}" >> ./release_changelog.md
+          echo "## [${{ steps.changelog_reader.outputs.version }}] - ${{ steps.changelog_reader.outputs.date }}" >> ./release_changelog.md
+          echo '${{ steps.changelog_reader.outputs.changes }}' >> ./release_changelog.md
+          echo "{\"text\":\"$(cat ./release_changelog.md)\"}" > ./slack-payload.json
+      - name: Send Slack notification
+        if: github.ref_type == 'tag'
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload-file-path: "./slack-payload.json"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_RELEASES }}


### PR DESCRIPTION
# What ❔

Restores proper sending of Slack notifications about new releases after [ITS-392](https://linear.app/matterlabs/issue/ITS-392/slack-webhook-for-compilers-repositories) fix.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To notify the other teams about new `zkvyper` releases.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
