### PR TITLE
ci: fix ccache installation on Linux with new docker

### DIFF
--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -25,7 +25,7 @@ runs:
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       run: |
         cargo install compiler-llvm-builder ${{ steps.build-target.outputs.target }} \
-          --git https://github.com/matter-labs/era-compiler-llvm-builder
+          --git https://github.com/matter-labs/era-compiler-llvm-builder --branch v1.0.18
         zkevm-llvm clone
 
     - name: Define ccache key

--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -36,6 +36,11 @@ runs:
         LLVM_SHORT_SHA="$(git -C ./llvm rev-parse --short HEAD)"
         echo "key=llvm-${LLVM_BRANCH}-${LLVM_SHORT_SHA}-${{ runner.os }}-${{ runner.arch }}" | tee -a "${GITHUB_OUTPUT}"
 
+    - name: Prepare ccache installation
+      if: runner.os == 'Linux'
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      run: apt update
+
     - name: Set up compiler cache
       uses: hendrikmuhs/ccache-action@v1.2
       env:


### PR DESCRIPTION
# What ❔

CI: `apt update` is required for docker container jobs to install `ccache` properly. See [here](https://github.com/hendrikmuhs/ccache-action?tab=readme-ov-file#usage).

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Fixing CI failures.
It worked before because the Docker container was not standardized, but after cleaning it up, this is required now.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
