### PR TITLE
Validate vyper only for Vyper input

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -45,7 +45,7 @@ pub fn build_vyper(
 ) -> anyhow::Result<Build> {
     check_dependencies();
 
-    let vyper = VyperCompiler::new(VyperCompiler::DEFAULT_EXECUTABLE_NAME.to_owned())?;
+    let vyper = VyperCompiler::new(VyperCompiler::DEFAULT_EXECUTABLE_NAME)?;
     if let Some((version, message)) = version_filter {
         if vyper.version.default != version {
             panic!("{}", message);

--- a/src/vyper/mod.rs
+++ b/src/vyper/mod.rs
@@ -53,16 +53,16 @@ impl Compiler {
     /// Different tools may use different `executable` names. For example, the integration tester
     /// uses `vyper-<version>` format.
     ///
-    pub fn new(executable: String) -> anyhow::Result<Self> {
-        if let Err(error) = which::which(executable.as_str()) {
+    pub fn new(executable: &str) -> anyhow::Result<Self> {
+        if let Err(error) = which::which(executable) {
             anyhow::bail!(
                 "The `{executable}` executable not found in ${{PATH}}: {}",
                 error
             );
         }
-        let version = Self::version(&executable)?;
+        let version = Self::version(executable)?;
         Ok(Self {
-            executable,
+            executable: executable.to_owned(),
             version,
         })
     }

--- a/src/zkvyper/main.rs
+++ b/src/zkvyper/main.rs
@@ -73,11 +73,6 @@ fn main_inner() -> anyhow::Result<()> {
         None => vec![],
     };
 
-    let vyper =
-        era_compiler_vyper::VyperCompiler::new(arguments.vyper.unwrap_or_else(|| {
-            era_compiler_vyper::VyperCompiler::DEFAULT_EXECUTABLE_NAME.to_owned()
-        }))?;
-
     let evm_version = match arguments.evm_version {
         Some(evm_version) => Some(era_compiler_common::EVMVersion::try_from(
             evm_version.as_str(),
@@ -123,6 +118,12 @@ fn main_inner() -> anyhow::Result<()> {
             debug_config,
         )
     } else {
+        let vyper = era_compiler_vyper::VyperCompiler::new(
+            arguments
+                .vyper
+                .as_deref()
+                .unwrap_or(era_compiler_vyper::VyperCompiler::DEFAULT_EXECUTABLE_NAME),
+        )?;
         match arguments.format.as_deref() {
             Some("combined_json") => {
                 era_compiler_vyper::combined_json(
@@ -178,6 +179,12 @@ fn main_inner() -> anyhow::Result<()> {
                 println!("0x{bytecode_string}");
 
                 if let Some(format) = arguments.format.as_deref() {
+                    let vyper = era_compiler_vyper::VyperCompiler::new(
+                        arguments
+                            .vyper
+                            .as_deref()
+                            .unwrap_or(era_compiler_vyper::VyperCompiler::DEFAULT_EXECUTABLE_NAME),
+                    )?;
                     let extra_output =
                         vyper.extra_output(PathBuf::from(path).as_path(), evm_version, format)?;
                     println!();


### PR DESCRIPTION
# What ❔

Checks for the `vyper` binary only in Vyper mode.

## Why ❔

The `vyper` binary was checked even in `--zkasm` mode.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
