### PR TITLE
Add the jump table density threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # The `zkvyper` changelog
 
+### [Unreleased]
+
+### Added
+
+- The jump table density threshold optimizer parameter
+
 ## [1.4.0] - 2024-02-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.4.1"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1594-add-the-jump-table-threshold-parameter-to-fe#518db5bcfda42e44cdf98b887ad4f07a4e88847b"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#7a7d7f8d1772c558c9dc6543148176700a6d9d51"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "era-compiler-vyper"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,9 +114,9 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.4.1"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#f1ae37a655c55ddc9c0bf08f3fbd00f99d38809e"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1594-add-the-jump-table-threshold-parameter-to-fe#518db5bcfda42e44cdf98b887ad4f07a4e88847b"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_def
 zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.4.1" }
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-cpr-1594-add-the-jump-table-threshold-parameter-to-fe" }
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era-compiler-vyper"
-version = "1.4.0"
+version = "1.4.1"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
 ]
@@ -35,7 +35,7 @@ zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_def
 zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.4.1" }
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-cpr-1594-add-the-jump-table-threshold-parameter-to-fe" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"

--- a/src/zkvyper/arguments.rs
+++ b/src/zkvyper/arguments.rs
@@ -47,6 +47,10 @@ pub struct Arguments {
     #[structopt(long = "disable-system-request-memoization")]
     pub disable_system_request_memoization: bool,
 
+    /// Set the jump table density threshold.
+    #[structopt(long = "jump-table-density-threshold")]
+    pub jump_table_density_threshold: Option<u32>,
+
     /// Disable the `vyper` LLL IR optimizer.
     #[structopt(long = "disable-vyper-optimizer")]
     pub disable_vyper_optimizer: bool,
@@ -168,6 +172,11 @@ impl Arguments {
             if self.disable_system_request_memoization {
                 anyhow::bail!(
                     "Disabling the system request memoization is not supported in EraVM assembly mode."
+                );
+            }
+            if self.jump_table_density_threshold.is_some() {
+                anyhow::bail!(
+                    "Setting the jump table density threshold is not supported in EraVM assembly mode."
                 );
             }
         }

--- a/src/zkvyper/main.rs
+++ b/src/zkvyper/main.rs
@@ -90,6 +90,9 @@ fn main_inner() -> anyhow::Result<()> {
     if arguments.disable_system_request_memoization {
         optimizer_settings.disable_system_request_memoization();
     }
+    if let Some(value) = arguments.jump_table_density_threshold {
+        optimizer_settings.set_jump_table_density_threshold(value);
+    }
     optimizer_settings.is_verify_each_enabled = arguments.llvm_verify_each;
     optimizer_settings.is_debug_logging_enabled = arguments.llvm_debug_logging;
 


### PR DESCRIPTION
# What ❔

Adds the jump table density threshold optimizer parameter.

## Why ❔

This parameter is required for the jump table optimization, which is useful for the EVM interpreter on EraVM.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
