### PR TITLE
Missing `--overwrite` now returns an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Printing `--help` if not arguments are provided
+- Missing `--overwrite` flag now triggers an error
 
 ## [1.4.0] - 2024-02-19
 

--- a/src/build/contract.rs
+++ b/src/build/contract.rs
@@ -54,7 +54,7 @@ impl Contract {
         assembly_file_path.push(assembly_file_name);
 
         if assembly_file_path.exists() && !overwrite {
-            eprintln!(
+            anyhow::bail!(
                 "Refusing to overwrite an existing file {assembly_file_path:?} (use --overwrite to force).",
             );
         } else {
@@ -77,7 +77,7 @@ impl Contract {
         binary_file_path.push(binary_file_name);
 
         if binary_file_path.exists() && !overwrite {
-            eprintln!(
+            anyhow::bail!(
                 "Refusing to overwrite an existing file {binary_file_path:?} (use --overwrite to force).",
             );
         } else {

--- a/src/vyper/combined_json/mod.rs
+++ b/src/vyper/combined_json/mod.rs
@@ -52,10 +52,9 @@ impl CombinedJson {
         file_path.push(format!("combined.{}", era_compiler_common::EXTENSION_JSON));
 
         if file_path.exists() && !overwrite {
-            eprintln!(
+            anyhow::bail!(
                 "Refusing to overwrite an existing file {file_path:?} (use --overwrite to force)."
             );
-            return Ok(());
         }
 
         File::create(&file_path)


### PR DESCRIPTION
# What ❔

Missing `--overwrite` now returns an error.

## Why ❔

Earlier, it would print an error and return exit code 0.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
