### PR TITLE
Print bytecode to --output-dir as a hex string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Printing `--help` if not arguments are provided
 - Missing `--overwrite` flag now triggers an error
+- Bytecode is now printed to `--output-dir` as a hex string
 
 ## [1.4.0] - 2024-02-19
 

--- a/src/build/contract.rs
+++ b/src/build/contract.rs
@@ -85,7 +85,7 @@ impl Contract {
                 .map_err(|error| {
                     anyhow::anyhow!("File {:?} creating error: {}", binary_file_path, error)
                 })?
-                .write_all(self.build.bytecode.as_slice())
+                .write_all(format!("0x{}", hex::encode(self.build.bytecode.as_slice())).as_bytes())
                 .map_err(|error| {
                     anyhow::anyhow!("File {:?} writing error: {}", binary_file_path, error)
                 })?;


### PR DESCRIPTION
# What ❔

Prints bytecode to --output-dir as a hex string.

## Why ❔

Binary format that was printed before, was unreadable and unusable by the tools.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
