### PR TITLE
fix: the broken pipe error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Printing `--help` if not arguments are provided
 - Missing `--overwrite` flag now triggers an error
 - Bytecode is now printed to `--output-dir` as a hex string
+- The broken pipe error when piping the output to another process
 
 ## [1.4.0] - 2024-02-19
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub use self::warning_type::WarningType;
 
 mod tests;
 
+use std::io::Write;
 use std::path::PathBuf;
 
 ///
@@ -197,10 +198,11 @@ pub fn combined_json(
 
             combined_json.write_to_directory(output_directory.as_path(), overwrite)?;
         }
-        None => println!(
+        None => writeln!(
+            std::io::stdout(),
             "{}",
             serde_json::to_string(&combined_json).expect("Always valid")
-        ),
+        )?,
     }
     std::process::exit(0);
 }


### PR DESCRIPTION
# What ❔

Fixes the broken pipe error.

## Why ❔

It is now possible to redirect the process output to another process.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
