### PR TITLE
ci: remove tests comments from PRs keeping checks only

### DIFF
--- a/.github/actions/cli-tests/action.yml
+++ b/.github/actions/cli-tests/action.yml
@@ -62,6 +62,7 @@ runs:
         check_name: CLI Tests ${{ runner.os }} ${{ runner.arch }} (prebuilt - ${{ inputs.use-prebuilt-zkvyper }})
         files: cli-tests/junit.xml
         action_fail_on_inconclusive: true
+        comment_mode: off
 
     - name: Upload results MacOS
       if: runner.os == 'macOS'
@@ -70,6 +71,7 @@ runs:
         check_name: CLI Tests Results ${{ runner.os }} ${{ runner.arch }} (prebuilt - ${{ inputs.use-prebuilt-zkvyper }})
         files: cli-tests/junit.xml
         action_fail_on_inconclusive: true
+        comment_mode: off
 
     - name: Upload results Windows
       if: runner.os == 'Windows'
@@ -78,3 +80,4 @@ runs:
         check_name: CLI Tests Results ${{ runner.os }} ${{ runner.arch }} (prebuilt - ${{ inputs.use-prebuilt-zkvyper }})
         files: cli-tests/junit.xml
         action_fail_on_inconclusive: true
+        comment_mode: off

--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -45,6 +45,7 @@ runs:
         check_name: ${{ runner.os }} ${{ runner.arch }} Unit Tests Results
         files: ${{ inputs.results-xml }}
         action_fail_on_inconclusive: true
+        comment_mode: off
 
     - name: Upload test results MacOS
       if: runner.os == 'macOS'
@@ -53,6 +54,7 @@ runs:
         check_name: ${{ runner.os }} ${{ runner.arch }} Unit Tests Results
         files: ${{ inputs.results-xml }}
         action_fail_on_inconclusive: true
+        comment_mode: off
 
     - name: Upload test results Windows
       if: runner.os == 'Windows'
@@ -61,3 +63,4 @@ runs:
         check_name: ${{ runner.os }} ${{ runner.arch }} Unit Tests Results
         files: ${{ inputs.results-xml }}
         action_fail_on_inconclusive: true
+        comment_mode: off


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Removes 6 comments from PRs about test results.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

To not flood too much in notifications keeping the same functional behavior.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
