### PR TITLE
build: use unique name for crt links

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,7 +19,7 @@ rustflags = [
 [target.aarch64-unknown-linux-musl]
 linker = "rust-lld"
 
-[target.aarch64-unknown-linux-musl.compiler-rt]
+[target.aarch64-unknown-linux-musl.compiler-rt-zkvyper]
 rustc-link-search = ["./target-llvm/target-host/lib/clang/17/lib/aarch64-unknown-linux-musl"]
 rustc-link-lib = ["clang_rt.builtins"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "EraVM Vyper compiler"
+links = "compiler-rt-zkvyper"
 
 [[bin]]
 name = "zkvyper"


### PR DESCRIPTION
# What ❔

Use an unique name for compiler-rt links for `aarch64-unknown-linux-arm` target.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To solve the linkage issue when both `zksolc` and `zkvyper` are used as a dependency.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
