### PR TITLE
fix: rename the system mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#bde99017add2c53a34a6cbcf2ba39560a3e72f53"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1699-switch-to-the-default-codegen-with-our-fork-of-solc#e011a780e83e0bf4d2454632ea72fbf153e7c08a"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_def
 zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.5.0" }
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-cpr-1699-switch-to-the-default-codegen-with-our-fork-of-solc" }
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"

--- a/src/project/contract/vyper/mod.rs
+++ b/src/project/contract/vyper/mod.rs
@@ -322,7 +322,7 @@ impl EraVMDependency for DependencyData {
         _contract: Self,
         _name: &str,
         _optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
-        _is_system_mode: bool,
+        _enable_eravm_extensions: bool,
         _include_metadata_hash: bool,
         _debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> anyhow::Result<String> {


### PR DESCRIPTION
# What ❔

Renames the system mode to EraVM extensions.

## Why ❔

The system mode definition is in conflict with some abstractions around the System Contracts.
The flag is merely enabling the EraVM extensions, so should be called this way.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
