### PR TITLE
feat: make vyper a singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - More LLVM optimizations
+- Caching of the underlying compiler's metadata, including `--version`
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,6 @@ dependencies = [
  "inkwell",
  "lazy_static",
  "mimalloc",
- "once_cell",
  "path-slash",
  "rayon",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ serde = { version = "1.0", "features" = [ "derive" ] }
 serde_json = { version = "1.0", features = [ "arbitrary_precision" ] }
 semver = { version = "1.0", features = [ "serde" ] }
 lazy_static = "1.4"
-once_cell = "1.19"
 hex = "0.4"
 sha3 = "0.10"
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -8,14 +8,13 @@ pub mod output;
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
-
-use once_cell::sync::OnceCell;
+use std::sync::OnceLock;
 
 use self::input::Input;
 use self::output::Output;
 
 /// The overridden executable name used when the compiler is run as a library.
-pub static EXECUTABLE: OnceCell<PathBuf> = OnceCell::new();
+pub static EXECUTABLE: OnceLock<PathBuf> = OnceLock::new();
 
 ///
 /// Read input from `stdin`, compile a contract, and write the output to `stdout`.

--- a/src/vyper/mod.rs
+++ b/src/vyper/mod.rs
@@ -7,9 +7,12 @@ pub mod standard_json;
 pub mod version;
 
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::sync::RwLock;
 
 use rayon::iter::IndexedParallelIterator;
 use rayon::iter::IntoParallelIterator;
@@ -29,16 +32,13 @@ use self::version::Version;
 ///
 /// The Vyper compiler.
 ///
+#[derive(Debug, Clone)]
 pub struct Compiler {
     /// The binary executable name.
     pub executable: String,
     /// The `vyper` compiler version.
     pub version: Version,
 }
-
-/// The executable which is only initialized once.
-/// It can optimize the compiler usage by caching `--version` and other output.
-pub static EXECUTABLE: once_cell::sync::OnceCell<Compiler> = once_cell::sync::OnceCell::new();
 
 impl Compiler {
     /// The default executable name.
@@ -57,20 +57,38 @@ impl Compiler {
     /// Different tools may use different `executable` names. For example, the integration tester
     /// uses `vyper-<version>` format.
     ///
-    pub fn new(executable: &str) -> anyhow::Result<&'static Self> {
-        EXECUTABLE.get_or_try_init(|| {
-            if let Err(error) = which::which(executable) {
-                anyhow::bail!(
-                    "The `{executable}` executable not found in ${{PATH}}: {}",
-                    error
-                );
-            }
-            let version = Self::parse_version(executable)?;
-            Ok(Self {
-                executable: executable.to_owned(),
-                version,
-            })
-        })
+    pub fn new(executable: &str) -> anyhow::Result<Self> {
+        if let Some(executable) = Self::executables()
+            .read()
+            .expect("Sync")
+            .get(executable)
+            .cloned()
+        {
+            return Ok(executable);
+        }
+
+        if let Err(error) = which::which(executable) {
+            anyhow::bail!(
+                "The `{executable}` executable not found in ${{PATH}}: {}",
+                error
+            );
+        }
+        let version = Self::parse_version(executable)?;
+        let compiler = Self {
+            executable: executable.to_owned(),
+            version,
+        };
+
+        Self::executables()
+            .write()
+            .expect("Sync")
+            .insert(executable.to_owned(), compiler);
+        Ok(Self::executables()
+            .read()
+            .expect("Sync")
+            .get(executable)
+            .cloned()
+            .expect("Always exists"))
     }
 
     ///
@@ -393,6 +411,14 @@ impl Compiler {
         }
 
         Ok(())
+    }
+
+    /// 
+    /// Returns the global shared array of `vyper` executables.
+    /// 
+    fn executables() -> &'static RwLock<HashMap<String, Self>> {
+        static EXECUTABLES: OnceLock<RwLock<HashMap<String, Compiler>>> = OnceLock::new();
+        EXECUTABLES.get_or_init(|| RwLock::new(HashMap::new()))
     }
 
     ///

--- a/src/vyper/version.rs
+++ b/src/vyper/version.rs
@@ -5,6 +5,7 @@
 ///
 /// The Vyper compiler version.
 ///
+#[derive(Debug, Clone)]
 pub struct Version {
     /// The long version string.
     pub long: String,

--- a/src/zkvyper/main.rs
+++ b/src/zkvyper/main.rs
@@ -133,7 +133,7 @@ fn main_inner() -> anyhow::Result<()> {
             Some("combined_json") => {
                 era_compiler_vyper::combined_json(
                     arguments.input_files,
-                    vyper,
+                    &vyper,
                     evm_version,
                     !arguments.disable_vyper_optimizer,
                     optimizer_settings,
@@ -150,7 +150,7 @@ fn main_inner() -> anyhow::Result<()> {
             }
             Some(_) | None => era_compiler_vyper::standard_output(
                 arguments.input_files,
-                vyper,
+                &vyper,
                 evm_version,
                 !arguments.disable_vyper_optimizer,
                 optimizer_settings,

--- a/src/zkvyper/main.rs
+++ b/src/zkvyper/main.rs
@@ -133,7 +133,7 @@ fn main_inner() -> anyhow::Result<()> {
             Some("combined_json") => {
                 era_compiler_vyper::combined_json(
                     arguments.input_files,
-                    &vyper,
+                    vyper,
                     evm_version,
                     !arguments.disable_vyper_optimizer,
                     optimizer_settings,
@@ -150,7 +150,7 @@ fn main_inner() -> anyhow::Result<()> {
             }
             Some(_) | None => era_compiler_vyper::standard_output(
                 arguments.input_files,
-                &vyper,
+                vyper,
                 evm_version,
                 !arguments.disable_vyper_optimizer,
                 optimizer_settings,


### PR DESCRIPTION
# What ❔

Makes `vyper` a singleton, initializing it and requesting `version` only once.

## Why ❔

It must reduce the number of spawned child processes, improving the general performance.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
