### PR TITLE
feat: read child process output in another thread

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -20,7 +20,8 @@ pub static EXECUTABLE: OnceLock<PathBuf> = OnceLock::new();
 /// Read input from `stdin`, compile a contract, and write the output to `stdout`.
 ///
 pub fn run() -> anyhow::Result<()> {
-    let input: Input = era_compiler_common::deserialize_from_reader(std::io::stdin())
+    let input_json = std::io::read_to_string(std::io::stdin()).expect("Stdin reading error");
+    let input: Input = era_compiler_common::deserialize_from_str(input_json.as_str())
         .expect("Stdin reading error");
 
     if input.enable_test_encoding {


### PR DESCRIPTION
# What ❔

Reads child process data in another thread.

## Why ❔

It should help with the excessive RAM usage in `solc`, which probably collects all its output before `zksolc` starts reading it.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
