### PR TITLE
feat: pass arbitrary options to LLVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@
 ### Added
 
 - More LLVM optimizations
+- The `--llvm-options` parameter to pass arbitrary options to LLVM
+- The `--threads` parameter to control the number of threads
 - Caching of the underlying compiler's metadata, including `--version`
+
+### Changed
+
+- Updated to EraVM v1.5.0
 
 ### Fixed
 
-- Excessive RAM usage with some projects
+- Excessive RAM usage and compilation time with some projects
+- Redundancy in error printing
 
 ## [1.4.1] - 2024-04-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#06ab4ba440469129da02cb578e3ebd06feb380d3"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1731-allow-passing-arbitrary-llvm-arguments-in-fe#dc5fcb596edadd9bd8fee26ffaa5d3bf0567f69c"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1731-allow-passing-arbitrary-llvm-arguments-in-fe#dc5fcb596edadd9bd8fee26ffaa5d3bf0567f69c"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#029dfd1f144d62774950ad014fbad3cb84fb93b3"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -934,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -1135,18 +1135,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1394,9 +1394,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "version_check"
@@ -1618,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zkevm-assembly"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_def
 zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.5.0" }
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-cpr-1731-allow-passing-arbitrary-llvm-arguments-in-fe" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_def
 zkevm-assembly = { git = "https://github.com/matter-labs/era-zkEVM-assembly", branch = "v1.5.0" }
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-cpr-1731-allow-passing-arbitrary-llvm-arguments-in-fe" }
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"

--- a/cli-tests/tests/llvm-ir.test.ts
+++ b/cli-tests/tests/llvm-ir.test.ts
@@ -57,7 +57,7 @@ describe("Set of --llvm-ir tests", () => {
         });
 
         it("Error is presented", () => {
-            expect(result.output).toMatch(/(compiling error)/i);
+            expect(result.output).toMatch(/(expected top-level entity)/i);
         });
     });
 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ use std::path::PathBuf;
 pub fn llvm_ir(
     mut input_files: Vec<PathBuf>,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    llvm_options: &[&str],
     include_metadata_hash: bool,
     suppressed_warnings: Vec<WarningType>,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
@@ -69,6 +70,7 @@ pub fn llvm_ir(
     let build = project.compile(
         None,
         optimizer_settings,
+        llvm_options,
         include_metadata_hash,
         zkevm_assembly::RunningVmEncodingMode::Production,
         suppressed_warnings,
@@ -83,6 +85,7 @@ pub fn llvm_ir(
 ///
 pub fn zkasm(
     mut input_files: Vec<PathBuf>,
+    llvm_options: &[&str],
     include_metadata_hash: bool,
     suppressed_warnings: Vec<WarningType>,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
@@ -102,6 +105,7 @@ pub fn zkasm(
     let build = project.compile(
         None,
         optimizer_settings,
+        llvm_options,
         include_metadata_hash,
         zkevm_assembly::RunningVmEncodingMode::Production,
         suppressed_warnings,
@@ -120,6 +124,7 @@ pub fn standard_output(
     evm_version: Option<era_compiler_common::EVMVersion>,
     vyper_optimizer_enabled: bool,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    llvm_options: &[&str],
     include_metadata_hash: bool,
     suppressed_warnings: Vec<WarningType>,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
@@ -141,6 +146,7 @@ pub fn standard_output(
     let build = project.compile(
         evm_version,
         optimizer_settings,
+        llvm_options,
         include_metadata_hash,
         zkevm_assembly::RunningVmEncodingMode::Production,
         suppressed_warnings,
@@ -159,6 +165,7 @@ pub fn combined_json(
     evm_version: Option<era_compiler_common::EVMVersion>,
     vyper_optimizer_enabled: bool,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    llvm_options: &[&str],
     include_metadata_hash: bool,
     suppressed_warnings: Vec<WarningType>,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
@@ -185,6 +192,7 @@ pub fn combined_json(
     let build = project.compile(
         evm_version,
         optimizer_settings,
+        llvm_options,
         include_metadata_hash,
         zkevm_assembly::RunningVmEncodingMode::Production,
         suppressed_warnings,

--- a/src/process/input.rs
+++ b/src/process/input.rs
@@ -29,6 +29,8 @@ pub struct Input<'a> {
     pub evm_version: Option<era_compiler_common::EVMVersion>,
     /// The optimizer settings.
     pub optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+    /// The extra LLVM arguments.
+    pub llvm_options: Vec<String>,
     /// The suppressed warnings.
     pub suppressed_warnings: Vec<WarningType>,
     /// The debug output config.
@@ -46,6 +48,7 @@ impl<'a> Input<'a> {
         enable_test_encoding: bool,
         evm_version: Option<era_compiler_common::EVMVersion>,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        llvm_options: Vec<String>,
         suppressed_warnings: Vec<WarningType>,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> Self {
@@ -56,6 +59,7 @@ impl<'a> Input<'a> {
             enable_test_encoding,
             evm_version,
             optimizer_settings,
+            llvm_options,
             suppressed_warnings,
             debug_config,
         }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -32,6 +32,7 @@ pub fn run() -> anyhow::Result<()> {
         input.source_code_hash,
         input.evm_version,
         input.optimizer_settings,
+        input.llvm_options,
         input.suppressed_warnings,
         input.debug_config,
     );
@@ -86,15 +87,15 @@ where
         anyhow::anyhow!("{executable:?} subprocess output reading error: {error:?}")
     })?;
     let stderr_message = String::from_utf8_lossy(result.stderr.as_slice());
+    if !result.status.success() {
+        anyhow::bail!("{stderr_message}");
+    }
     let output = match era_compiler_common::deserialize_from_slice::<O>(result.stdout.as_slice()) {
         Ok(combined_json) => combined_json,
         Err(error) => {
             anyhow::bail!("{executable:?} subprocess stdout parsing error: {error:?} (stderr: {stderr_message})");
         }
     };
-    if !result.status.success() {
-        anyhow::bail!("{executable:?} error: {stderr_message}");
-    }
 
     Ok(output)
 }

--- a/src/project/contract/llvm_ir.rs
+++ b/src/project/contract/llvm_ir.rs
@@ -39,6 +39,7 @@ impl Contract {
         contract_path: &str,
         source_code_hash: Option<[u8; era_compiler_common::BYTE_LENGTH_FIELD]>,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        llvm_options: Vec<String>,
         _suppressed_warnings: Vec<WarningType>,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> anyhow::Result<ContractBuild> {
@@ -68,6 +69,7 @@ impl Contract {
         >::new(
             &llvm,
             module,
+            llvm_options,
             optimizer,
             None,
             metadata_hash.is_some(),

--- a/src/project/contract/llvm_ir.rs
+++ b/src/project/contract/llvm_ir.rs
@@ -53,6 +53,7 @@ impl Contract {
                 None,
                 semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Always valid"),
                 optimizer.settings().to_owned(),
+                llvm_options.as_slice(),
             )
             .keccak256()
         });

--- a/src/project/contract/metadata.rs
+++ b/src/project/contract/metadata.rs
@@ -22,6 +22,8 @@ pub struct Metadata<'a> {
     pub zk_version: semver::Version,
     /// The EraVM compiler stringified optimizer settings.
     pub optimizer_settings: String,
+    /// The LLVM extra arguments.
+    pub llvm_options: &'a [String],
 }
 
 impl<'a> Metadata<'a> {
@@ -34,6 +36,7 @@ impl<'a> Metadata<'a> {
         evm_version: Option<era_compiler_common::EVMVersion>,
         zk_version: semver::Version,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        llvm_options: &'a [String],
     ) -> Self {
         Self {
             source_hash,
@@ -41,6 +44,7 @@ impl<'a> Metadata<'a> {
             evm_version,
             zk_version,
             optimizer_settings: optimizer_settings.to_string(),
+            llvm_options,
         }
     }
 

--- a/src/project/contract/mod.rs
+++ b/src/project/contract/mod.rs
@@ -58,6 +58,7 @@ impl Contract {
         source_code_hash: Option<[u8; era_compiler_common::BYTE_LENGTH_FIELD]>,
         evm_version: Option<era_compiler_common::EVMVersion>,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        llvm_options: Vec<String>,
         suppressed_warnings: Vec<WarningType>,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> anyhow::Result<ContractBuild> {
@@ -67,6 +68,7 @@ impl Contract {
                 source_code_hash,
                 evm_version,
                 optimizer_settings,
+                llvm_options,
                 suppressed_warnings,
                 debug_config,
             ),
@@ -74,6 +76,7 @@ impl Contract {
                 contract_path,
                 source_code_hash,
                 optimizer_settings,
+                llvm_options,
                 suppressed_warnings,
                 debug_config,
             ),

--- a/src/project/contract/mod.rs
+++ b/src/project/contract/mod.rs
@@ -84,6 +84,7 @@ impl Contract {
                 contract_path,
                 source_code_hash,
                 optimizer_settings,
+                llvm_options,
                 suppressed_warnings,
                 debug_config,
             ),

--- a/src/project/contract/vyper/expression/instruction/deploy.rs
+++ b/src/project/contract/vyper/expression/instruction/deploy.rs
@@ -32,7 +32,7 @@ impl Deploy {
 
         match expression {
             Expression::Instruction(Instruction::Seq(sequence)) => Ok((sequence, immutables_size)),
-            expression => anyhow::bail!("Expected `seq`, found `{:?}`", expression),
+            expression => anyhow::bail!("Expected `seq`, found `{expression:?}`"),
         }
     }
 }

--- a/src/project/contract/vyper/expression/instruction/label.rs
+++ b/src/project/contract/vyper/expression/instruction/label.rs
@@ -144,7 +144,7 @@ impl Label {
                 }
             }
             Some(Expression::Identifier(identifier)) if identifier.as_str() == "var_list" => {}
-            expression => anyhow::bail!("Expected a variable list, found `{:?}`", expression),
+            expression => anyhow::bail!("Expected a variable list, found `{expression:?}`"),
         };
 
         context

--- a/src/project/contract/vyper/expression/instruction/mod.rs
+++ b/src/project/contract/vyper/expression/instruction/mod.rs
@@ -349,10 +349,8 @@ impl Instruction {
 
         if values.len() != N {
             anyhow::bail!(
-                "Expected {} arguments, found only {}: `{:?}`",
-                N,
+                "Expected {N} arguments, found only {}: `{values:?}`",
                 values.len(),
-                values
             );
         }
 
@@ -397,10 +395,8 @@ impl Instruction {
 
         if values.len() != N {
             anyhow::bail!(
-                "Expected {} arguments, found only {}: `{:?}`",
-                N,
+                "Expected {N} arguments, found only {}: `{values:?}`",
                 values.len(),
-                values
             );
         }
 
@@ -437,7 +433,7 @@ impl Instruction {
     pub fn function_name(&self) -> anyhow::Result<String> {
         match self {
             Self::Seq(inner) => inner.function_name(),
-            expression => anyhow::bail!("Expected a function sequence, found `{:?}`", expression),
+            expression => anyhow::bail!("Expected a function sequence, found `{expression:?}`"),
         }
     }
 
@@ -1141,9 +1137,7 @@ impl Instruction {
 
                 match context.code_type() {
                     None => {
-                        anyhow::bail!(
-                            "Immutables are not available if the contract part is undefined"
-                        );
+                        panic!("code part is undefined");
                     }
                     Some(era_compiler_llvm_context::CodeType::Deploy) => {
                         era_compiler_llvm_context::eravm_evm_calldata::load(
@@ -1589,7 +1583,7 @@ impl Instruction {
             }
 
             Self::Unknown(value) => {
-                anyhow::bail!("Unknown LLL instruction: {}", value);
+                anyhow::bail!("Unknown LLL instruction: {value}");
             }
         }
     }

--- a/src/project/contract/vyper/expression/instruction/seq.rs
+++ b/src/project/contract/vyper/expression/instruction/seq.rs
@@ -140,7 +140,7 @@ impl Seq {
     pub fn function_name(&self) -> anyhow::Result<String> {
         match self.0.first() {
             Some(Expression::Instruction(Instruction::Label(label))) => label.name(),
-            expression => anyhow::bail!("Expected a function sequence, found `{:?}`", expression),
+            expression => anyhow::bail!("Expected a function sequence, found `{expression:?}`"),
         }
     }
 

--- a/src/project/contract/vyper/expression/mod.rs
+++ b/src/project/contract/vyper/expression/mod.rs
@@ -54,7 +54,7 @@ impl Expression {
                 sequence.normalize_deploy_code();
                 Ok(sequence)
             }
-            instruction => anyhow::bail!("Expected [`seq`, `deploy`], found `{:?}`", instruction),
+            instruction => anyhow::bail!("Expected [`seq`, `deploy`], found `{instruction:?}`"),
         }
     }
 
@@ -77,7 +77,7 @@ impl Expression {
                 runtime_code.normalize_runtime_code();
                 Ok(Some((runtime_code, immutables_size)))
             }
-            instruction => anyhow::bail!("Expected [`seq`, `deploy`], found `{:?}`", instruction),
+            instruction => anyhow::bail!("Expected [`seq`, `deploy`], found `{instruction:?}`"),
         }
     }
 
@@ -87,7 +87,7 @@ impl Expression {
     pub fn try_into_identifier(&self) -> anyhow::Result<String> {
         match self {
             Self::Identifier(string) => Ok(string.to_owned()),
-            expression => anyhow::bail!("Expected identifier, found `{:?}`", expression),
+            expression => anyhow::bail!("Expected identifier, found `{expression:?}`"),
         }
     }
 
@@ -117,7 +117,7 @@ impl Expression {
     pub fn function_name(&self) -> anyhow::Result<String> {
         match self {
             Expression::Instruction(inner) => inner.function_name(),
-            expression => anyhow::bail!("Expected a function sequence, found `{:?}`", expression),
+            expression => anyhow::bail!("Expected a function sequence, found `{expression:?}`"),
         }
     }
 
@@ -180,7 +180,7 @@ impl Expression {
             }
 
             Self::Unknown(value) => {
-                anyhow::bail!("Unknown LLL expression: {}", value);
+                anyhow::bail!("Unknown LLL expression: {value}");
             }
         }
     }

--- a/src/project/contract/vyper/mod.rs
+++ b/src/project/contract/vyper/mod.rs
@@ -135,6 +135,7 @@ impl Contract {
                 evm_version,
                 semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Always valid"),
                 optimizer.settings().to_owned(),
+                llvm_options.as_slice(),
             )
             .keccak256()
         });

--- a/src/project/contract/vyper/mod.rs
+++ b/src/project/contract/vyper/mod.rs
@@ -117,6 +117,7 @@ impl Contract {
         source_code_hash: Option<[u8; era_compiler_common::BYTE_LENGTH_FIELD]>,
         evm_version: Option<era_compiler_common::EVMVersion>,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        llvm_options: Vec<String>,
         suppressed_warnings: Vec<WarningType>,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> anyhow::Result<ContractBuild> {
@@ -142,6 +143,7 @@ impl Contract {
         let mut context = era_compiler_llvm_context::EraVMContext::<DependencyData>::new(
             &llvm,
             llvm.create_module(contract_path),
+            llvm_options,
             optimizer,
             Some(dependency_data),
             metadata_hash.is_some(),
@@ -233,14 +235,14 @@ where
             Expression::IntegerLiteral(number) => {
                 let immutables_size = number
                     .as_u64()
-                    .ok_or_else(|| anyhow::anyhow!("Immutable size `{}` parsing error", number))?;
+                    .ok_or_else(|| anyhow::anyhow!("Immutable size `{number}` parsing error"))?;
                 let vyper_data = era_compiler_llvm_context::EraVMContextVyperData::new(
                     immutables_size as usize,
                     false,
                 );
                 context.set_vyper_data(vyper_data);
             }
-            expression => anyhow::bail!("Invalid immutables size format: {:?}", expression),
+            expression => anyhow::bail!("Invalid immutables size format: {expression:?}"),
         }
 
         let mut function_expressions = deploy_code
@@ -322,6 +324,7 @@ impl EraVMDependency for DependencyData {
         _contract: Self,
         _name: &str,
         _optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        _llvm_options: &[String],
         _is_system_mode: bool,
         _include_metadata_hash: bool,
         _debug_config: Option<era_compiler_llvm_context::DebugConfig>,
@@ -330,10 +333,10 @@ impl EraVMDependency for DependencyData {
     }
 
     fn resolve_path(&self, _identifier: &str) -> anyhow::Result<String> {
-        anyhow::bail!("The dependency mechanism is not available in Vyper");
+        anyhow::bail!("Dependency mechanism is not available in Vyper");
     }
 
     fn resolve_library(&self, _path: &str) -> anyhow::Result<String> {
-        anyhow::bail!("The dependency mechanism is not available in Vyper");
+        anyhow::bail!("Dependency mechanism is not available in Vyper");
     }
 }

--- a/src/project/contract/zkasm.rs
+++ b/src/project/contract/zkasm.rs
@@ -39,6 +39,7 @@ impl Contract {
         contract_path: &str,
         source_code_hash: Option<[u8; era_compiler_common::BYTE_LENGTH_FIELD]>,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
+        llvm_options: Vec<String>,
         _suppressed_warnings: Vec<WarningType>,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> anyhow::Result<ContractBuild> {
@@ -49,6 +50,7 @@ impl Contract {
                 None,
                 semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Always valid"),
                 optimizer_settings,
+                llvm_options.as_slice(),
             )
             .keccak256()
         });

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -73,6 +73,7 @@ pub fn build_vyper(
     let build = project.compile(
         None,
         optimizer_settings,
+        &[],
         false,
         zkevm_assembly::RunningVmEncodingMode::Production,
         vec![],

--- a/src/zkvyper/arguments.rs
+++ b/src/zkvyper/arguments.rs
@@ -54,6 +54,10 @@ pub struct Arguments {
     #[structopt(long = "jump-table-density-threshold")]
     pub jump_table_density_threshold: Option<u32>,
 
+    /// Pass arbitary space-separated options to LLVM.
+    #[structopt(long = "llvm-options")]
+    pub llvm_options: Option<String>,
+
     /// Disable the `vyper` LLL IR optimizer.
     #[structopt(long = "disable-vyper-optimizer")]
     pub disable_vyper_optimizer: bool,
@@ -72,6 +76,10 @@ pub struct Arguments {
     /// See `vyper --help` for available options including combined JSON mode.
     #[structopt(short = "f")]
     pub format: Option<String>,
+
+    /// Sets the number of threads, which execute the tests concurrently.
+    #[structopt(short = "t", long = "threads")]
+    pub threads: Option<usize>,
 
     /// Switch to LLVM IR mode.
     /// Only one input LLVM IR file is allowed.


### PR DESCRIPTION
# What ❔

Allows passing arbitrary LLVM arguments in FE.

## Why ❔

It is needed for experiments with the optimizer, and for debugging.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
