### PR TITLE
ci: add proper matrix configuration when platforms are off

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Git REF to use for manual pre-release"
-        required: true
+        description: "Git REF to use for manual pre-release. Keep it empty to use the workflow branch."
+        required: false
         type: string
       prerelease_suffix:
         description: "Suffix which has been used for manual pre-release name"
@@ -41,62 +41,60 @@ on:
     tags:
       - "*.*.*"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
+
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.prepare-matrix.outputs.matrix }}
+    steps:
+      - name: Prepare matrix
+        id: prepare-matrix
+        run: |
+          # Define general matrix parameters
+          WINDOWS='{"name":"Windows","runner":"windows-2022-github-hosted-64core","release-suffix":"windows-amd64"}'
+          MACOS_AMD64='{"name":"MacOS-x86","runner":"macos-12-large","release-suffix":"macosx-amd64"}'
+          MACOS_ARM64='{"name":"MacOS-arm64","runner":["self-hosted","macOS","ARM64"],"release-suffix":"macosx-arm64"}'
+          LINUX_AMD64='{"name":"Linux-AMD64","runner":"matterlabs-ci-runner","image":"matterlabs/llvm_runner:ubuntu22-llvm17-latest","target":"x86_64-unknown-linux-musl","release-suffix":"linux-amd64-musl"}'
+          LINUX_ARM64='{"name":"Linux-ARM64","runner":"matterlabs-ci-runner-arm","image":"matterlabs/llvm_runner:ubuntu22-llvm17-latest","target":"aarch64-unknown-linux-musl","release-suffix":"linux-arm64-musl"}'
+          # Disable platforms for non-tag builds if user requested
+          if [ ${GITHUB_REF_TYPE} != tag ]; then
+            [ ${{ github.event.inputs.release_windows_amd64 }} != true ] && WINDOWS=
+            [ ${{ github.event.inputs.release_macos_amd64 }} != true ] && MACOS_AMD64=
+            [ ${{ github.event.inputs.release_macos_arm64 }} != true ] && MACOS_ARM64=
+            [ ${{ github.event.inputs.release_linux_amd64 }} != true ] && LINUX_AMD64=
+            [ ${{ github.event.inputs.release_linux_arm64 }} != true ] && LINUX_ARM64=
+          fi
+          PLATFORMS=(${WINDOWS} ${MACOS_AMD64} ${MACOS_ARM64} ${LINUX_AMD64} ${LINUX_ARM64})
+          echo "matrix={ \"include\": [ $(IFS=, ; echo "${PLATFORMS[*]}") ] }" | tee -a "${GITHUB_OUTPUT}"
+
   build:
+    needs: prepare-matrix
     strategy:
-      matrix:
-        include:
-          - name: "MacOS x86"
-            runner: macos-12-large
-            release-suffix: macosx-amd64
-            required: ${{ github.event.inputs.release_macos_amd64 }}
-          - name: "MacOS arm64"
-            runner: [self-hosted, macOS, ARM64]
-            release-suffix: macosx-arm64
-            required: ${{ github.event.inputs.release_macos_arm64 }}
-          - name: "Linux x86"
-            runner: matterlabs-ci-runner
-            image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
-            target: "x86_64-unknown-linux-musl"
-            release-suffix: linux-amd64-musl
-            required: ${{ github.event.inputs.release_linux_amd64 }}
-          - name: "Linux ARM64"
-            runner: matterlabs-ci-runner-arm
-            image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
-            target: "aarch64-unknown-linux-musl"
-            release-suffix: linux-arm64-musl
-            required: ${{ github.event.inputs.release_linux_arm64 }}
-          - name: "Windows"
-            runner: windows-2022-github-hosted-16core
-            release-suffix: windows-amd64-gnu
-            required: ${{ github.event.inputs.release_windows_amd64 }}
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
     container:
       image: ${{ matrix.image || '' }} # Special workaround to allow matrix builds with optional container
     name: ${{ matrix.name }}
     steps:
-
       - name: Checkout source
-        if: matrix.required == 'true'
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || '' }}
 
       - name: Prepare Windows env
-        if: matrix.required == 'true' && runner.os == 'Windows'
+        if: runner.os == 'Windows'
         uses: matter-labs/era-compiler-ci/.github/actions/prepare-msys@main
 
       - name: Build LLVM
-        if: matrix.required == 'true'
         uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@main
         with:
           target-env: 'musl'
           enable-assertions: 'false'
 
       - name: Build zkvyper
-        if: matrix.required == 'true'
         uses: ./.github/actions/build
         with:
           target: ${{ matrix.target }}


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Dynamically create a build/release matrix instead of skipping steps.

## Tests

* [Test with all jobs](https://github.com/matter-labs/era-compiler-vyper/actions/runs/9404515340)
* [Test with 3 jobs](https://github.com/matter-labs/era-compiler-vyper/actions/runs/9404507501)
* [Test with no jobs](https://github.com/matter-labs/era-compiler-vyper/actions/runs/9404548872)

## Why ❔

This will not overload runners just to skip all steps and speed up builds.

Related to [CPR-1733](https://linear.app/matterlabs/issue/CPR-1733/improve-zksolczkvyper-matrix-jobs-to-disable-completely-if-the)

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
