### PR TITLE
ci: fix release with special symbols in changelog

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -31,7 +31,7 @@ runs:
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       run: |
         mkdir -p ./releases/${{ inputs.release-suffix }}
-        [ ! -z "$GITHUB_REF_NAME" ] && TAG_SUFFIX="-${GITHUB_REF_NAME}"
+        [ ! -z "$GITHUB_REF_NAME" ] && TAG_SUFFIX="-v${GITHUB_REF_NAME}"
         [ "$RUNNER_OS" = "Windows" ] && WIN_SUFFIX=".exe"
         strip ./target/${{ matrix.target }}/release/zkvyper${WIN_SUFFIX}
         mv ./target/${{ matrix.target }}/release/zkvyper${WIN_SUFFIX} \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,18 +131,6 @@ jobs:
             echo "release_title=${VERSION_OR_SHA}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          tree ./releases
-          BINARIES=($(find ./releases -type f))
-          [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && TARGET_PARAM="--target ${{ steps.release.outputs.full_sha }}"
-          gh release create ${{ steps.release.outputs.version_or_sha }} \
-            --title ${{ steps.release.outputs.release_title }} \
-            --prerelease ${TARGET_PARAM} \
-            "${BINARIES[@]}"
-
       - name: Get changelog
         if: github.ref_type == 'tag'
         id: changelog_reader
@@ -151,22 +139,13 @@ jobs:
           validation_level: warn
           path: ./CHANGELOG.md
 
-      - name: Prepare CHANGELOG for publishing
-        id: prepare_changelog
-        if: github.ref_type == 'tag'
-        run: |
-          echo "## ${{ github.event.repository.name }}" >> ./release_changelog.md
-          echo "## [${{ steps.changelog_reader.outputs.version }}] - ${{ steps.changelog_reader.outputs.date }}" >> ./release_changelog.md
-          echo '${{ steps.changelog_reader.outputs.changes }}' >> ./release_changelog.md
-          echo "changes=$(sed -z 's/\n/\\n/g' ./release_changelog.md)" >> $GITHUB_OUTPUT
-
-      - name: Send Slack notification
-        if: github.ref_type == 'tag'
-        uses: slackapi/slack-github-action@v1.25.0
+      - name: Prepare release
+        uses: softprops/action-gh-release@v2
         with:
-          payload: |
-            {
-              "text": "${{ steps.prepare_changelog.outputs.changes }}"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_RELEASES }}
+          name: ${{ steps.release.outputs.release_title }}
+          body: ${{ steps.changelog_reader.outputs.changes }}
+          generate_release_notes: false
+          tag_name: ${{ steps.release.outputs.version_or_sha }}
+          target_commitish: ${{ steps.release.outputs.full_sha }}
+          prerelease: true
+          files: releases/**/**


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

* [x] Use release action instead of `gh api`
* [x] Remove error-prone Slack notification

## Why ❔

Related to [CPR-1379](https://linear.app/matterlabs/issue/CPR-1739/fix-the-changelog-publishing)

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->
There always can be some unexpected special symbols in the changelog that are impossible to filter or escape properly while manually creating the Slack notification from the changelog entry This PR is a proposal to never do this, and instead use GitHub <--> Slack integration to subscribe to the `releases` in the repository forwarding the required release notification in the common group when the release is out and verified.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
