### PR TITLE
fix: combined_json format check

### DIFF
--- a/cli-tests/tests/common.test.ts
+++ b/cli-tests/tests/common.test.ts
@@ -66,7 +66,6 @@ describe("Common tests", () => {
 
         it("Output file is created", () => {
             expect(isDestinationExist(paths.pathToBinOutputFile)).toBe(true);
-            expect(isDestinationExist(paths.pathToEraVMAssemblyOutputFile)).toBe(true);
         });
         it("The output file is not empty", () => {
             expect(isFileEmpty(paths.pathToBinOutputFile)).toBe(false);

--- a/cli-tests/tests/format.test.ts
+++ b/cli-tests/tests/format.test.ts
@@ -5,27 +5,7 @@ describe("Set of --format json tests", () => {
     const zkvyperCommand = 'zkvyper';
     const vyperCommand = 'vyper';
     const format_args: string[] = [
-        `bytecode`,
-        `bytecode_runtime`,
-        `blueprint_bytecode`,
-        `abi`,
-        `abi_python`,
-        `source_map`,
-        `method_identifiers`,
-        `userdoc`,
-        `devdoc`,
-        `combined_json`,
-        `layout`,
-        `ast`,
-        `interface`,
-        `external_interface`,
-        `opcodes`,
-        `opcodes_runtime`,
-        `ir`,
-        `ir_json`,
-        `ir_runtime`,
-        `asm`
-        // `hex-ir` // does not work
+        `combined_json`
     ];
 
     //id1988
@@ -59,7 +39,7 @@ describe("Set of --format json tests", () => {
         });
 
         it("Error is presented", () => {
-            expect(result.output).toMatch(/([Uu]nsupported format)/i);
+            expect(result.output).toMatch(/(is the only output format supported)/i);
         });
     });
 

--- a/cli-tests/tests/output-dir.test.ts
+++ b/cli-tests/tests/output-dir.test.ts
@@ -25,6 +25,46 @@ describe("Output dir", () => {
 
         it("Output files are created", () => {
             expect(isDestinationExist(pathToBinOutputFile(tmpDirZkVyper.name))).toBe(true);
+        });
+
+        it("The output files are not empty", () => {
+            expect(isFileEmpty(pathToBinOutputFile(tmpDirZkVyper.name))).toBe(false);
+        });
+
+        it("No 'Error'/'Warning'/'Fail' in the output", () => {
+            expect(result.output).not.toMatch(/([Ee]rror|[Ww]arning|[Ff]ail)/i);
+            tmpDirZkVyper.removeCallback()
+        });
+
+        xit("vyper exit code == zkvyper exit code", () => {
+            const tmpDirVyper = createTmpDirectory();
+            const args = [`"${paths.pathToBasicVyContract}"`, `-o`, `"${tmpDirVyper.name}"`];
+            const vyperResult = executeCommand(vyperCommand, args);
+            expect(vyperResult.exitCode).toBe(result.exitCode);
+            tmpDirVyper.removeCallback()
+        });
+    });
+
+    //id1983
+    describe("Default run with output dir and assembly", () => {
+        const tmpDirZkVyper = createTmpDirectory();
+        const args = [`"${paths.pathToBasicVyContract}"`, `-o`, `"${tmpDirZkVyper.name}"`, `--output-assembly`];
+        const result = executeCommand(zkvyperCommand, args);
+
+        it("Output is empty", () => {
+            expect(result.output).not.toMatch(/(Refusing to overwrite)/i);
+        });
+
+        it("Exit code = 0", () => {
+            expect(result.exitCode).toBe(0);
+        });
+
+        it("Output dir is created", () => {
+            expect(isDestinationExist(tmpDirZkVyper.name)).toBe(true);
+        });
+
+        it("Output files are created", () => {
+            expect(isDestinationExist(pathToBinOutputFile(tmpDirZkVyper.name))).toBe(true);
             expect(isDestinationExist(pathToEraVMAssemblyOutputFile(tmpDirZkVyper.name))).toBe(true);
         });
 

--- a/cli-tests/tests/overwrite.test.ts
+++ b/cli-tests/tests/overwrite.test.ts
@@ -38,7 +38,6 @@ describe("Overwrite output dir", () => {
         // verify that files are not empty
         it("The output files are not empty", () => {
             expect(isFileEmpty(pathToBinOutputFile(tmpDirZkVyper.name))).toBe(false);
-            expect(isFileEmpty(pathToEraVMAssemblyOutputFile(tmpDirZkVyper.name))).toBe(false);
         });
 
         it("No 'Error'/'Warning'/'Fail' in the output", () => {

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -63,7 +63,7 @@ impl Build {
                             .normalize()
                             .expect("Path normalization error");
                         let json_path = PathBuf::from(json_path.as_str())
-                            .canonicalize()
+                            .normalize()
                             .expect("Path normalization error");
 
                         if path.ends_with(json_path) {

--- a/src/zkvyper/main.rs
+++ b/src/zkvyper/main.rs
@@ -158,10 +158,12 @@ fn main_inner() -> anyhow::Result<()> {
                 )?;
                 return Ok(());
             }
-            Some(format) if format.split(',').any(|format| format == "combined_json") => {
-                anyhow::bail!("`combined_json` must be the only output format requested");
+            Some(format) => {
+                anyhow::bail!(
+                    "`combined_json` is the only output format supported, found `{format}`"
+                );
             }
-            Some(_) | None => era_compiler_vyper::standard_output(
+            None => era_compiler_vyper::standard_output(
                 arguments.input_files,
                 &vyper,
                 evm_version,


### PR DESCRIPTION
# What ❔

Fixes some unit tests and combined JSON output on Windows.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
