### PR TITLE
feat: compile multiple IR contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Assembly is now only returned if requested with `--output-assembly`
+- Renamed the `zkasm` flag to `eravm-assembly`
 - Updated to Rust v1.79.0
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- The support for compiling multiple files in Yul, LLVM IR, and EraVM assembly modes
+
 ### Changed
 
 - Assembly is now only returned if requested with `--output-assembly`

--- a/cli-tests/tests/eravm-assembly.test.ts
+++ b/cli-tests/tests/eravm-assembly.test.ts
@@ -1,34 +1,48 @@
 import {executeCommand} from "../src/helper";
 import { paths } from '../src/entities';
 
-describe("Set of --eravm tests", () => {
+describe("Set of --eravm-assembly tests", () => {
     const zkvyperCommand = 'zkvyper';
 
     //id1961
-    describe(`Run ${zkvyperCommand} with --eravm by default`, () => {
-        const args = [`${paths.pathToBasicEraVMAssemblyContract}`, `--eravm`];
+    describe(`Run ${zkvyperCommand} with --eravm-assembly by default`, () => {
+        const args = [`${paths.pathToBasicEraVMAssemblyContract}`, `--eravm-assembly`];
         const result = executeCommand(zkvyperCommand, args);
 
         it("Valid command exit code = 0", () => {
             expect(result.exitCode).toBe(0);
         });
 
-        it("--eravm output is presented", () => {
+        it("Output is presented", () => {
             expect(result.output).toMatch(/(0x)/i);
+        });
+    });
+
+    //id1963:II
+    describe(`Run with only --eravm-assembly option`, () => {
+        const args = [`--eravm-assembly`];
+        const result = executeCommand(zkvyperCommand, args);
+
+        it("Valid command exit code = 0", () => {
+            expect(result.exitCode).toBe(0);
+        });
+
+        it("Error is presented", () => {
+            expect(result.output).toMatch(/(No input sources provided)/i);
         });
     });
 
     //id1962
     describe(`Run ${zkvyperCommand} with double EraVM assembly options`, () => {
-        const args = [`${paths.pathToBasicEraVMAssemblyContract}`, `--eravm`, `--eravm`];
+        const args = [`${paths.pathToBasicEraVMAssemblyContract}`, `--eravm-assembly`, `--eravm-assembly`];
         const result = executeCommand(zkvyperCommand, args);
 
         it("Valid command exit code = 1", () => {
             expect(result.exitCode).toBe(1);
         });
 
-        it("--eravm error is presented", () => {
-            expect(result.output).toMatch(/(The argument '--eravm' was provided more than once)/i);
+        it("--eravm-assembly error is presented", () => {
+            expect(result.output).toMatch(/(The argument '--eravm-assembly' was provided more than once)/i);
         });
     });
 });

--- a/cli-tests/tests/format.test.ts
+++ b/cli-tests/tests/format.test.ts
@@ -5,7 +5,26 @@ describe("Set of --format json tests", () => {
     const zkvyperCommand = 'zkvyper';
     const vyperCommand = 'vyper';
     const format_args: string[] = [
-        `combined_json`
+        `bytecode`,
+        `bytecode_runtime`,
+        `blueprint_bytecode`,
+        `abi`,
+        `abi_python`,
+        `source_map`,
+        `method_identifiers`,
+        `userdoc`,
+        `devdoc`,
+        `combined_json`,
+        `layout`,
+        `ast`,
+        `interface`,
+        `external_interface`,
+        `opcodes`,
+        `opcodes_runtime`,
+        `ir`,
+        `ir_json`,
+        `ir_runtime`,
+        `asm`,
     ];
 
     //id1988

--- a/cli-tests/tests/format.test.ts
+++ b/cli-tests/tests/format.test.ts
@@ -49,7 +49,7 @@ describe("Set of --format json tests", () => {
     }
 
     //id1989
-    describe(`Run ${zkvyperCommand} with Unsupported format and --format option`, () => {
+    describe(`Run ${zkvyperCommand} with unsupported format and --format option`, () => {
         const args = [`${paths.pathToBasicVyContract}`, `-f`, `llvm`];
         const result = executeCommand(zkvyperCommand, args);
 
@@ -58,7 +58,7 @@ describe("Set of --format json tests", () => {
         });
 
         it("Error is presented", () => {
-            expect(result.output).toMatch(/(is the only output format supported)/i);
+            expect(result.output).toMatch(/(Unsupported format type)/i);
         });
     });
 

--- a/cli-tests/tests/llvm-ir.test.ts
+++ b/cli-tests/tests/llvm-ir.test.ts
@@ -19,16 +19,16 @@ describe("Set of --llvm-ir tests", () => {
     });
 
     //id1963:II
-    describe(`Run only with --llvm-ir options`, () => {
+    describe(`Run with only --llvm-ir option`, () => {
         const args = [`--llvm-ir`];
         const result = executeCommand(zkvyperCommand, args);
 
-        it("Valid command exit code = 1", () => {
-            expect(result.exitCode).toBe(1);
+        it("Valid command exit code = 0", () => {
+            expect(result.exitCode).toBe(0);
         });
 
         it("Error is presented", () => {
-            expect(result.output).toMatch(/(input file is missing)/i);
+            expect(result.output).toMatch(/(No input sources provided)/i);
         });
     });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub use self::vyper::Compiler as VyperCompiler;
 
 mod tests;
 
+use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -57,6 +58,10 @@ pub fn llvm_ir(
     suppressed_messages: Vec<MessageType>,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
 ) -> anyhow::Result<Build> {
+    if input_files.is_empty() {
+        writeln!(std::io::stderr(), "No input sources provided").expect("Stderr writing error");
+    }
+
     let paths: Vec<&Path> = input_files.iter().map(|path| path.as_path()).collect();
     let project = Project::try_from_llvm_ir_paths(paths.as_slice())?;
 
@@ -70,7 +75,6 @@ pub fn llvm_ir(
         suppressed_messages,
         debug_config,
     )?;
-
     Ok(build)
 }
 
@@ -85,10 +89,14 @@ pub fn eravm_assembly(
     suppressed_messages: Vec<MessageType>,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
 ) -> anyhow::Result<Build> {
+    if input_files.is_empty() {
+        writeln!(std::io::stderr(), "No input sources provided").expect("Stderr writing error");
+    }
+
     let paths: Vec<&Path> = input_files.iter().map(|path| path.as_path()).collect();
     let project = Project::try_from_eravm_assembly_paths(paths.as_slice())?;
 
-    let optimizer_settings = era_compiler_llvm_context::OptimizerSettings::none();
+    let optimizer_settings = era_compiler_llvm_context::OptimizerSettings::cycles();
     let build = project.compile(
         None,
         include_metadata_hash,
@@ -99,7 +107,6 @@ pub fn eravm_assembly(
         suppressed_messages,
         debug_config,
     )?;
-
     Ok(build)
 }
 
@@ -142,7 +149,6 @@ pub fn standard_output(
         suppressed_messages,
         debug_config,
     )?;
-
     Ok(build)
 }
 

--- a/src/message_type.rs
+++ b/src/message_type.rs
@@ -1,5 +1,5 @@
 //!
-//! The compiler warning type.
+//! The compiler message type.
 //!
 
 use std::str::FromStr;
@@ -8,10 +8,10 @@ use serde::Deserialize;
 use serde::Serialize;
 
 ///
-/// The compiler warning type.
+/// The compiler message type.
 ///
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum WarningType {
+pub enum MessageType {
     /// The warning for eponymous feature.
     EcRecover,
     /// The warning for eponymous feature.
@@ -20,9 +20,9 @@ pub enum WarningType {
     TxOrigin,
 }
 
-impl WarningType {
+impl MessageType {
     ///
-    /// Converts string arguments into an array of warnings.
+    /// Converts string arguments into an array of messages.
     ///
     pub fn try_from_strings(strings: &[String]) -> Result<Vec<Self>, anyhow::Error> {
         strings
@@ -32,7 +32,7 @@ impl WarningType {
     }
 }
 
-impl FromStr for WarningType {
+impl FromStr for MessageType {
     type Err = anyhow::Error;
 
     fn from_str(string: &str) -> Result<Self, Self::Err> {
@@ -40,7 +40,7 @@ impl FromStr for WarningType {
             "ecrecover" => Ok(Self::EcRecover),
             "extcodesize" => Ok(Self::ExtCodeSize),
             "txorigin" => Ok(Self::TxOrigin),
-            _ => Err(anyhow::anyhow!("Invalid warning: {}", string)),
+            _ => Err(anyhow::anyhow!("Invalid message type: {string}")),
         }
     }
 }

--- a/src/process/input.rs
+++ b/src/process/input.rs
@@ -9,8 +9,8 @@ use std::borrow::Cow;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::message_type::MessageType;
 use crate::project::contract::Contract;
-use crate::warning_type::WarningType;
 
 ///
 /// The input data.
@@ -33,8 +33,8 @@ pub struct Input<'a> {
     pub llvm_options: Vec<String>,
     /// Whether to output EraVM assembly.
     pub output_assembly: bool,
-    /// The suppressed warnings.
-    pub suppressed_warnings: Vec<WarningType>,
+    /// The suppressed messages.
+    pub suppressed_messages: Vec<MessageType>,
     /// The debug output config.
     pub debug_config: Option<era_compiler_llvm_context::DebugConfig>,
 }
@@ -52,7 +52,7 @@ impl<'a> Input<'a> {
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
         llvm_options: Vec<String>,
         output_assembly: bool,
-        suppressed_warnings: Vec<WarningType>,
+        suppressed_messages: Vec<MessageType>,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> Self {
         Self {
@@ -64,7 +64,7 @@ impl<'a> Input<'a> {
             optimizer_settings,
             llvm_options,
             output_assembly,
-            suppressed_warnings,
+            suppressed_messages,
             debug_config,
         }
     }

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -34,7 +34,7 @@ pub fn run() -> anyhow::Result<()> {
         input.optimizer_settings,
         input.llvm_options,
         input.output_assembly,
-        input.suppressed_warnings,
+        input.suppressed_messages,
         input.debug_config,
     )?;
 

--- a/src/project/contract/eravm_assembly.rs
+++ b/src/project/contract/eravm_assembly.rs
@@ -6,8 +6,8 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::build::contract::Contract as ContractBuild;
+use crate::message_type::MessageType;
 use crate::project::contract::metadata::Metadata as ContractMetadata;
-use crate::warning_type::WarningType;
 
 ///
 /// The EraVM assembly contract.
@@ -41,7 +41,7 @@ impl Contract {
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
         llvm_options: Vec<String>,
         output_assembly: bool,
-        _suppressed_warnings: Vec<WarningType>,
+        _suppressed_messages: Vec<MessageType>,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> anyhow::Result<ContractBuild> {
         let metadata_hash = source_code_hash.map(|source_code_hash| {

--- a/src/project/contract/llvm_ir.rs
+++ b/src/project/contract/llvm_ir.rs
@@ -3,8 +3,8 @@
 //!
 
 use crate::build::contract::Contract as ContractBuild;
+use crate::message_type::MessageType;
 use crate::project::contract::metadata::Metadata as ContractMetadata;
-use crate::warning_type::WarningType;
 
 ///
 /// The LLVM IR contract.
@@ -38,7 +38,7 @@ impl Contract {
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
         llvm_options: Vec<String>,
         output_assembly: bool,
-        _suppressed_warnings: Vec<WarningType>,
+        _suppressed_messages: Vec<MessageType>,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> anyhow::Result<ContractBuild> {
         let llvm = inkwell::context::Context::create();

--- a/src/project/contract/mod.rs
+++ b/src/project/contract/mod.rs
@@ -8,7 +8,7 @@ pub mod metadata;
 pub mod vyper;
 
 use crate::build::contract::Contract as ContractBuild;
-use crate::warning_type::WarningType;
+use crate::message_type::MessageType;
 
 use self::eravm_assembly::Contract as EraVMAssemblyContract;
 use self::llvm_ir::Contract as LLVMIRContract;
@@ -57,7 +57,7 @@ impl Contract {
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
         llvm_options: Vec<String>,
         output_assembly: bool,
-        suppressed_warnings: Vec<WarningType>,
+        suppressed_messages: Vec<MessageType>,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> anyhow::Result<ContractBuild> {
         match self {
@@ -68,7 +68,7 @@ impl Contract {
                 optimizer_settings,
                 llvm_options,
                 output_assembly,
-                suppressed_warnings,
+                suppressed_messages,
                 debug_config,
             ),
             Self::LLVMIR(inner) => inner.compile(
@@ -77,7 +77,7 @@ impl Contract {
                 optimizer_settings,
                 llvm_options,
                 output_assembly,
-                suppressed_warnings,
+                suppressed_messages,
                 debug_config,
             ),
             Self::EraVMAssembly(inner) => inner.compile(
@@ -86,7 +86,7 @@ impl Contract {
                 optimizer_settings,
                 llvm_options,
                 output_assembly,
-                suppressed_warnings,
+                suppressed_messages,
                 debug_config,
             ),
         }

--- a/src/project/contract/vyper/ast.rs
+++ b/src/project/contract/vyper/ast.rs
@@ -5,8 +5,8 @@
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::message_type::MessageType;
 use crate::vyper::combined_json::contract::warning::Warning as CombinedJsonContractWarning;
-use crate::warning_type::WarningType;
 
 ///
 /// The Vyper contract AST.
@@ -33,20 +33,20 @@ impl AST {
     pub fn get_messages(
         &self,
         ast: &serde_json::Value,
-        suppressed_warnings: &[WarningType],
+        suppressed_messages: &[MessageType],
     ) -> Vec<CombinedJsonContractWarning> {
         let mut messages = Vec::new();
-        if !suppressed_warnings.contains(&WarningType::EcRecover) {
+        if !suppressed_messages.contains(&MessageType::EcRecover) {
             if let Some(message) = self.check_ecrecover(ast) {
                 messages.push(message);
             }
         }
-        if !suppressed_warnings.contains(&WarningType::ExtCodeSize) {
+        if !suppressed_messages.contains(&MessageType::ExtCodeSize) {
             if let Some(message) = self.check_extcodesize(ast) {
                 messages.push(message);
             }
         }
-        if !suppressed_warnings.contains(&WarningType::TxOrigin) {
+        if !suppressed_messages.contains(&MessageType::TxOrigin) {
             if let Some(message) = self.check_tx_origin(ast) {
                 messages.push(message);
             }
@@ -55,12 +55,12 @@ impl AST {
         match ast {
             serde_json::Value::Array(array) => {
                 for element in array.iter() {
-                    messages.extend(self.get_messages(element, suppressed_warnings));
+                    messages.extend(self.get_messages(element, suppressed_messages));
                 }
             }
             serde_json::Value::Object(object) => {
                 for (_key, value) in object.iter() {
-                    messages.extend(self.get_messages(value, suppressed_warnings));
+                    messages.extend(self.get_messages(value, suppressed_messages));
                 }
             }
             _ => {}

--- a/src/project/contract/vyper/mod.rs
+++ b/src/project/contract/vyper/mod.rs
@@ -12,10 +12,10 @@ use era_compiler_llvm_context::EraVMWriteLLVM;
 use era_compiler_llvm_context::IContext;
 
 use crate::build::contract::Contract as ContractBuild;
+use crate::message_type::MessageType;
 use crate::metadata::Metadata as SourceMetadata;
 use crate::project::contract::metadata::Metadata as ContractMetadata;
 use crate::project::dependency_data::DependencyData;
-use crate::warning_type::WarningType;
 
 use self::ast::AST;
 use self::expression::Expression;
@@ -115,12 +115,12 @@ impl Contract {
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
         llvm_options: Vec<String>,
         output_assembly: bool,
-        suppressed_warnings: Vec<WarningType>,
+        suppressed_messages: Vec<MessageType>,
         debug_config: Option<era_compiler_llvm_context::DebugConfig>,
     ) -> anyhow::Result<ContractBuild> {
         let warnings = self
             .ast
-            .get_messages(&self.ast.ast, suppressed_warnings.as_slice());
+            .get_messages(&self.ast.ast, suppressed_messages.as_slice());
 
         let llvm = inkwell::context::Context::create();
         let optimizer = era_compiler_llvm_context::Optimizer::new(optimizer_settings);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -14,6 +14,7 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use crate::build::Build;
+use crate::project::Project;
 use crate::vyper::standard_json::input::settings::selection::Selection as VyperStandardJsonInputSettingsSelection;
 use crate::vyper::standard_json::input::Input as VyperStandardJsonInput;
 use crate::vyper::Compiler as VyperCompiler;
@@ -69,7 +70,7 @@ pub fn build_vyper(
 
     let output = vyper.standard_json(input)?;
 
-    let project = output.try_into_project(&vyper.version.default)?;
+    let project = Project::try_from_standard_json(output, &vyper.version.default)?;
     let build = project.compile(
         None,
         false,

--- a/src/vyper/combined_json/mod.rs
+++ b/src/vyper/combined_json/mod.rs
@@ -57,6 +57,7 @@ impl CombinedJson {
             );
         }
 
+        std::fs::create_dir_all(output_directory)?;
         File::create(&file_path)
             .map_err(|error| anyhow::anyhow!("File {:?} creating error: {}", file_path, error))?
             .write_all(serde_json::to_vec(&self).expect("Always valid").as_slice())

--- a/src/vyper/mod.rs
+++ b/src/vyper/mod.rs
@@ -16,8 +16,6 @@ use std::sync::RwLock;
 use rayon::iter::IndexedParallelIterator;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
-use sha3::digest::FixedOutput;
-use sha3::Digest;
 
 use crate::project::contract::vyper::Contract as VyperContract;
 use crate::project::contract::Contract;
@@ -340,14 +338,7 @@ impl Compiler {
                     Ok::<BTreeMap<String, Contract>, anyhow::Error>(accumulator)
                 })?;
 
-        let mut source_code_hasher = sha3::Keccak256::new();
-        for (_path, contract) in contracts.iter() {
-            source_code_hasher.update(contract.source_code().as_bytes());
-        }
-        let source_code_hash: [u8; era_compiler_common::BYTE_LENGTH_FIELD] =
-            source_code_hasher.finalize_fixed().into();
-
-        let project = Project::new(version.to_owned(), source_code_hash, contracts);
+        let project = Project::new(version.to_owned(), contracts);
 
         Ok(project)
     }

--- a/src/vyper/standard_json/output/mod.rs
+++ b/src/vyper/standard_json/output/mod.rs
@@ -7,16 +7,6 @@ pub mod error;
 
 use std::collections::BTreeMap;
 
-use serde::Deserialize;
-use sha3::digest::FixedOutput;
-use sha3::Digest;
-
-use crate::metadata::Metadata as SourceMetadata;
-use crate::project::contract::vyper::ast::AST as VyperAST;
-use crate::project::contract::vyper::Contract as VyperContract;
-use crate::project::contract::Contract as ProjectContract;
-use crate::project::Project;
-
 use self::contract::Contract;
 use self::error::Error;
 
@@ -26,7 +16,7 @@ use self::error::Error;
 /// Unlike in the Solidity compiler, it is not passed up to the hardhat plugin, but only used here
 /// internally to reduce the number of calls to the `vyper` subprocess.
 ///
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct Output {
     /// The contracts hashmap.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -41,61 +31,4 @@ pub struct Output {
     #[serde(rename = "compiler")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub long_version: Option<String>,
-}
-
-impl Output {
-    ///
-    /// Converts the `vyper` JSON output into a convenient project.
-    ///
-    pub fn try_into_project(mut self, version: &semver::Version) -> anyhow::Result<Project> {
-        let files = match self.contracts.take() {
-            Some(files) => files,
-            None => {
-                anyhow::bail!(
-                    "{}",
-                    self.errors
-                        .as_ref()
-                        .map(|errors| serde_json::to_string_pretty(errors).expect("Always valid"))
-                        .unwrap_or_else(|| "Unknown project assembling error".to_owned())
-                );
-            }
-        };
-
-        let mut project_contracts: BTreeMap<String, ProjectContract> = BTreeMap::new();
-        for (path, file) in files.into_iter() {
-            for (name, contract) in file.into_iter() {
-                let full_path = format!("{path}:{name}");
-
-                let ast = self
-                    .sources
-                    .as_ref()
-                    .and_then(|sources| sources.get(&path).cloned())
-                    .ok_or_else(|| anyhow::anyhow!("No AST for contract {}", full_path))?;
-                let ast = VyperAST::new(full_path.clone(), ast);
-
-                let project_contract = VyperContract::new(
-                    version.to_owned(),
-                    contract.source_code.expect("Must be set by the tester"),
-                    SourceMetadata::default(),
-                    contract.ir,
-                    contract.evm.abi,
-                    ast,
-                );
-                project_contracts.insert(full_path, project_contract.into());
-            }
-        }
-
-        let mut source_code_hasher = sha3::Keccak256::new();
-        for (_path, contract) in project_contracts.iter() {
-            source_code_hasher.update(contract.source_code().as_bytes());
-        }
-        let source_code_hash: [u8; era_compiler_common::BYTE_LENGTH_FIELD] =
-            source_code_hasher.finalize_fixed().into();
-
-        Ok(Project::new(
-            version.to_owned(),
-            source_code_hash,
-            project_contracts,
-        ))
-    }
 }

--- a/src/zkvyper/arguments.rs
+++ b/src/zkvyper/arguments.rs
@@ -84,7 +84,7 @@ pub struct Arguments {
     /// Only one input EraVM assembly file is allowed.
     /// Cannot be used with combined JSON modes.
     /// Use this mode at your own risk, as EraVM assembly input validation is not implemented.
-    #[structopt(long = "eravm", alias = "zkasm")]
+    #[structopt(long = "eravm-assembly")]
     pub eravm_assembly: bool,
 
     /// Set metadata hash mode: `keccak256` | `none`.

--- a/src/zkvyper/main.rs
+++ b/src/zkvyper/main.rs
@@ -157,12 +157,12 @@ fn main_inner() -> anyhow::Result<()> {
                 )?;
                 return Ok(());
             }
-            Some(format) => {
+            Some(format) if format.split(',').any(|element| element == "combined_json") => {
                 anyhow::bail!(
-                    "`combined_json` is the only output format supported, found `{format}`"
+                    "`combined_json` cannot be requested together with other output: consider removing it from `{format}`"
                 );
             }
-            None => era_compiler_vyper::standard_output(
+            Some(_) | None => era_compiler_vyper::standard_output(
                 arguments.input_files,
                 &vyper,
                 evm_version,


### PR DESCRIPTION
# What ❔

Adds the support for compiling multiple contracts written in LLVM IR and EraVM assembly.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
