### PR TITLE
ci: add more vyper executables available for unit tests

### DIFF
--- a/.github/actions/install-vyper/action.yml
+++ b/.github/actions/install-vyper/action.yml
@@ -1,14 +1,22 @@
 name: 'Install vyper'
 description: 'Installs the vyper compiler.'
 inputs:
-  vyper-version:
+  vyper-default-name:
+    description: 'Default name of the vyper executable.'
+    required: false
+    default: 'vyper'
+  vyper-versions:
     description: 'Version of vyper compiler to download.'
     required: false
-    default: '0.4.0'
-  vyper-commit:
-    description: 'Commit of vyper compiler to download.'
+    default: 'vyper.0.3.3+commit.48e326f0 vyper.0.3.9+commit.66b96705 vyper.0.3.10+commit.91361694 vyper.0.4.0+commit.e9db8d9f'
+  vyper-version-latest:
+    description: 'Latest version of vyper compiler to download.'
     required: false
-    default: 'e9db8d9f'
+    default: 'vyper.0.4.0+commit.e9db8d9f'
+  output-dir:
+    description: 'Output directory for the solc binaries.'
+    required: false
+    default: 'vyper-bins'
 runs:
   using: "composite"
   steps:
@@ -16,25 +24,27 @@ runs:
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       env:
         VYPER_DOWNLOAD_URL: "https://github.com/vyperlang/vyper/releases/download"
-        VYPER_VERSION: ${{ inputs.vyper-version || '0.4.0' }}
-        VYPER_COMMIT: ${{ inputs.vyper-commit || 'e9db8d9f' }}
       run: |
-        VYPER_DOWNLOAD_FILENAME="vyper.${VYPER_VERSION}+commit.${VYPER_COMMIT}"
-        case "$RUNNER_OS" in
-          Linux*)
-            OUTPUT=vyper
-            VYPER_DOWNLOAD_EXTENSION=".linux"
-            ;;
-          macOS*)
-            OUTPUT=vyper
-            VYPER_DOWNLOAD_EXTENSION=".darwin"
-            ;;
-          Windows*)
-            OUTPUT=vyper.exe
-            VYPER_DOWNLOAD_EXTENSION=".windows.exe"
-            ;;
-        esac
-        curl --location -o $OUTPUT \
-          "${VYPER_DOWNLOAD_URL}/v${VYPER_VERSION}/${VYPER_DOWNLOAD_FILENAME}${VYPER_DOWNLOAD_EXTENSION}"
-        chmod a+x ${OUTPUT}
-        echo "${PWD}" >> "${GITHUB_PATH}"
+        mkdir -p ${{ inputs.output-dir }}
+        for VYPER_FULL_VERSION in ${{ inputs.vyper-versions }}; do
+          case "$RUNNER_OS" in
+            Linux*)
+              VYPER_DOWNLOAD_EXTENSION=".linux"
+              ;;
+            macOS*)
+              VYPER_DOWNLOAD_EXTENSION=".darwin"
+              ;;
+            Windows*)
+              WIN_SUFFIX=.exe
+              VYPER_DOWNLOAD_EXTENSION=".windows.exe"
+              ;;
+          esac
+          VYPER_VERSION="$(echo "${VYPER_FULL_VERSION}" | sed -E 's/.*${{ inputs.vyper-default-name }}\.([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+          OUTPUT="${{ inputs.output-dir }}/${{ inputs.vyper-default-name }}-${VYPER_VERSION}${WIN_SUFFIX}"
+          curl --location -o "${OUTPUT}" \
+            "${VYPER_DOWNLOAD_URL}/v${VYPER_VERSION}/${VYPER_FULL_VERSION}${VYPER_DOWNLOAD_EXTENSION}"
+          chmod a+x "${OUTPUT}"
+          [ ${VYPER_FULL_VERSION} = ${{ inputs.vyper-version-latest }} ] && cp "${OUTPUT}" "${{ inputs.output-dir }}/${{ inputs.vyper-default-name }}${WIN_SUFFIX}"
+        done
+        echo "${PWD}/${{ inputs.output-dir }}" >> "${GITHUB_PATH}"
+        ls -la ${PWD}/${{ inputs.output-dir }}


### PR DESCRIPTION
# What ❔

Add more vyper executables for unit tests:
* `0.3.3`
* `0.3.9`
* `0.3.10`
* `0.4.0`

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To catch incompatibilities with older vyper versions.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
