### PR TITLE
fix: the minimal proxy path error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # The `zkvyper` changelog
 
+## [1.5.2] - 2024-07-01
+
+### Fixed
+
+- Path normalization error with the internal minimal proxy contract
+
+### Removed
+
+- Obsolete warnings for `extcodesize` and `ecrecover`
+
 ## [1.5.1] - 2024-06-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,9 +114,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.101"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac367972e516d45567c7eafc73d24e1c193dcf200a8d94e9db7b3d38b349572d"
+checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
 
 [[package]]
 name = "cfg-if"
@@ -299,14 +299,13 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#d7be90b6918f05b9d77d4ac4cc2949a3525baf19"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#31946ecd883be041c5b232a85a778501f4cc3d85"
 dependencies = [
  "anyhow",
  "era-compiler-common",
  "hex",
  "inkwell",
  "itertools",
- "md5",
  "num",
  "semver",
  "serde",
@@ -317,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "era-compiler-vyper"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -655,15 +654,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
@@ -1154,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.118"
+version = "1.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
+checksum = "e8eddb61f0697cc3989c5d64b452f5488e2b8a60fd7d5076a3045076ffef8cb0"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "era-compiler-vyper"
-version = "1.5.1"
+version = "1.5.2"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
 ]

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -104,12 +104,8 @@ impl Build {
                     .contracts
                     .iter_mut()
                     .find_map(|(json_path, contract)| {
-                        let path = PathBuf::from(path.as_str())
-                            .normalize()
-                            .expect("Path normalization error");
-                        let json_path = PathBuf::from(json_path.as_str())
-                            .normalize()
-                            .expect("Path normalization error");
+                        let path = PathBuf::from(path.as_str()).normalize().ok()?;
+                        let json_path = PathBuf::from(json_path.as_str()).normalize().ok()?;
 
                         if path.ends_with(json_path) {
                             Some(contract)


### PR DESCRIPTION
# What ❔

Fixes the path normalization crash with contracts containing the minimal proxy.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
