### PR TITLE
chore: use better alt for logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ZKsync Era: Vyper Compiler
 
-[![Logo](eraLogo.svg)](https://zksync.io/)
+[![ZKsync Era Logo](eraLogo.svg)](https://zksync.io/)
 
 ZKsync Era is a layer 2 rollup that uses zero-knowledge proofs to scale Ethereum without compromising on security
 or decentralization. As it’s EVM-compatible (with Solidity/Vyper), 99% of Ethereum projects can redeploy without


### PR DESCRIPTION
This PR adds more details to the `alt` used for the logo on the README