### PR TITLE
chore: fix comment for `lib.rs`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //!
-//! Vyper compiler library.
+//! The Vyper compiler library.
 //!
 
 #![allow(non_camel_case_types)]


### PR DESCRIPTION
The comment for `lib.rs` should be prefixed with `The`.