### PR TITLE
fix: error code when no input files provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - The support for IPFS metadata hash type
 - The EraVM disassembler
 
+### Fixed
+
+- The error code when no input files are provided
+
 ## [1.5.4] - 2024-08-27
 
 ### Added

--- a/src/zkvyper/arguments.rs
+++ b/src/zkvyper/arguments.rs
@@ -146,14 +146,18 @@ impl Arguments {
     /// Validates the arguments.
     ///
     pub fn validate(&self) -> anyhow::Result<()> {
+        if self.recursive_process {
+            if std::env::args().count() > 2 {
+                anyhow::bail!("Error: No other options are allowed in recursive mode.");
+            } else {
+                return Ok(());
+            }
+        }
+
         if self.version && std::env::args().count() > 2 {
             anyhow::bail!(
                 "Error: No other options are allowed while getting the compiler version."
             );
-        }
-
-        if self.recursive_process && std::env::args().count() > 2 {
-            anyhow::bail!("Error: No other options are allowed in recursive mode.");
         }
 
         if self.input_paths.is_empty() {

--- a/src/zkvyper/arguments.rs
+++ b/src/zkvyper/arguments.rs
@@ -156,6 +156,10 @@ impl Arguments {
             anyhow::bail!("Error: No other options are allowed in recursive mode.");
         }
 
+        if self.input_paths.is_empty() {
+            anyhow::bail!("Error: No input files provided.");
+        }
+
         let modes_count = [
             self.llvm_ir,
             self.eravm_assembly,
@@ -169,6 +173,10 @@ impl Arguments {
             anyhow::bail!(
                 "Error: Only one modes is allowed at the same time: Vyper, LLVM IR, EraVM assembly, disassembler."
             );
+        }
+
+        if self.disassemble && std::env::args().count() > self.input_paths.len() + 2 {
+            anyhow::bail!("Error: No other options are allowed in disassembler mode.");
         }
 
         if self.llvm_ir || self.eravm_assembly {
@@ -195,10 +203,6 @@ impl Arguments {
                     "Error: Falling back to -Oz is not supported in EraVM assembly mode."
                 );
             }
-        }
-
-        if self.disassemble && std::env::args().count() > self.input_paths.len() + 2 {
-            anyhow::bail!("Error: No other options are allowed in disassembler mode.");
         }
 
         Ok(())

--- a/tests/cli/basic.rs
+++ b/tests/cli/basic.rs
@@ -28,6 +28,23 @@ fn run_zkvyper_without_any_options() -> anyhow::Result<()> {
 
 /// id1978
 #[test]
+fn default_run_without_input_files() -> anyhow::Result<()> {
+    let _ = common::setup();
+    let args = &["-f", "ast"];
+
+    // Execute zkvyper command
+    let result = cli::execute_zkvyper(args)?;
+    let zkvyper_status = result.get_output().status.code().expect("No exit code.");
+
+    // Compare with vyper
+    let vyper_result = cli::execute_vyper(args)?;
+    vyper_result.code(zkvyper_status);
+
+    Ok(())
+}
+
+/// id1978
+#[test]
 fn default_run_with_a_contract_only() -> anyhow::Result<()> {
     let _ = common::setup();
     let args = &[cli::TEST_VYPER_CONTRACT_PATH];

--- a/tests/cli/basic.rs
+++ b/tests/cli/basic.rs
@@ -37,7 +37,10 @@ fn default_run_without_input_files() -> anyhow::Result<()> {
     let zkvyper_status = result
         .failure()
         .stderr(predicate::str::contains("No input files provided"))
-        .get_output().status.code().expect("No exit code.");
+        .get_output()
+        .status
+        .code()
+        .expect("No exit code.");
 
     // Compare with vyper
     // Use `ge` predicate to check if zkvyper exit code is greater than or equal to vyper exit code

--- a/tests/cli/basic.rs
+++ b/tests/cli/basic.rs
@@ -34,11 +34,16 @@ fn default_run_without_input_files() -> anyhow::Result<()> {
 
     // Execute zkvyper command
     let result = cli::execute_zkvyper(args)?;
-    let zkvyper_status = result.get_output().status.code().expect("No exit code.");
+    let zkvyper_status = result
+        .failure()
+        .stderr(predicate::str::contains("No input files provided"))
+        .get_output().status.code().expect("No exit code.");
 
     // Compare with vyper
+    // Use `ge` predicate to check if zkvyper exit code is greater than or equal to vyper exit code
+    // because vyper exit code is 2, but zkvyper exit code is 1
     let vyper_result = cli::execute_vyper(args)?;
-    vyper_result.code(zkvyper_status);
+    vyper_result.code(predicate::ge(zkvyper_status));
 
     Ok(())
 }

--- a/tests/cli/debug_output_dir.rs
+++ b/tests/cli/debug_output_dir.rs
@@ -55,9 +55,9 @@ fn run_without_contract_with_debug_output_dir() -> anyhow::Result<()> {
 
     // Execute zkvyper command
     let result = cli::execute_zkvyper(args)?;
-    result.failure().stderr(predicate::str::contains(
-        "No input files provided",
-    ));
+    result
+        .failure()
+        .stderr(predicate::str::contains("No input files provided"));
 
     Ok(())
 }

--- a/tests/cli/debug_output_dir.rs
+++ b/tests/cli/debug_output_dir.rs
@@ -56,7 +56,7 @@ fn run_without_contract_with_debug_output_dir() -> anyhow::Result<()> {
     // Execute zkvyper command
     let result = cli::execute_zkvyper(args)?;
     result.failure().stderr(predicate::str::contains(
-        "the following arguments are required",
+        "No input files provided",
     ));
 
     Ok(())

--- a/tests/cli/disable_vyper_optimizer.rs
+++ b/tests/cli/disable_vyper_optimizer.rs
@@ -22,9 +22,9 @@ fn run_only_with_disable_vyper_optimizer() -> anyhow::Result<()> {
 
     // Execute zkvyper command
     let result = cli::execute_zkvyper(args)?;
-    result.failure().stderr(predicate::str::contains(
-        "No input files provided",
-    ));
+    result
+        .failure()
+        .stderr(predicate::str::contains("No input files provided"));
 
     Ok(())
 }

--- a/tests/cli/disable_vyper_optimizer.rs
+++ b/tests/cli/disable_vyper_optimizer.rs
@@ -23,7 +23,7 @@ fn run_only_with_disable_vyper_optimizer() -> anyhow::Result<()> {
     // Execute zkvyper command
     let result = cli::execute_zkvyper(args)?;
     result.failure().stderr(predicate::str::contains(
-        "the following arguments are required",
+        "No input files provided",
     ));
 
     Ok(())

--- a/tests/cli/eravm_assembly.rs
+++ b/tests/cli/eravm_assembly.rs
@@ -23,8 +23,8 @@ fn run_only_with_eravm_assembly_option() -> anyhow::Result<()> {
     // Execute zkvyper command
     let result = cli::execute_zkvyper(args)?;
     result
-        .success()
-        .stderr(predicate::str::contains("No input sources provided"));
+        .failure()
+        .stderr(predicate::str::contains("No input files provided"));
 
     Ok(())
 }

--- a/tests/cli/fallback.rs
+++ b/tests/cli/fallback.rs
@@ -22,9 +22,9 @@ fn run_only_with_fallback_oz_option() -> anyhow::Result<()> {
 
     // Execute zkvyper command
     let result = cli::execute_zkvyper(args)?;
-    result.failure().stderr(predicate::str::contains(
-        "No input files provided",
-    ));
+    result
+        .failure()
+        .stderr(predicate::str::contains("No input files provided"));
 
     Ok(())
 }

--- a/tests/cli/fallback.rs
+++ b/tests/cli/fallback.rs
@@ -23,7 +23,7 @@ fn run_only_with_fallback_oz_option() -> anyhow::Result<()> {
     // Execute zkvyper command
     let result = cli::execute_zkvyper(args)?;
     result.failure().stderr(predicate::str::contains(
-        "the following arguments are required",
+        "No input files provided",
     ));
 
     Ok(())

--- a/tests/cli/llvm_debug_log.rs
+++ b/tests/cli/llvm_debug_log.rs
@@ -24,7 +24,7 @@ fn run_only_with_llvm_debug_logging() -> anyhow::Result<()> {
     let result = cli::execute_zkvyper(args)?;
     result
         .failure()
-        .stderr(predicate::str::contains("arguments are required"));
+        .stderr(predicate::str::contains("No input files provided"));
 
     Ok(())
 }

--- a/tests/cli/llvm_ir.rs
+++ b/tests/cli/llvm_ir.rs
@@ -21,11 +21,10 @@ fn run_only_with_llvm_ir() -> anyhow::Result<()> {
     let args = &["--llvm-ir"];
 
     // Execute zkvyper command
-    // TODO: change success() to failure() after CPR-1804 fix
     let result = cli::execute_zkvyper(args)?;
     result
-        .success()
-        .stderr(predicate::str::contains("No input sources provided"));
+        .failure()
+        .stderr(predicate::str::contains("No input files provided"));
 
     Ok(())
 }

--- a/tests/cli/llvm_verify_each.rs
+++ b/tests/cli/llvm_verify_each.rs
@@ -24,7 +24,7 @@ fn run_only_with_llvm_verify_each() -> anyhow::Result<()> {
     let result = cli::execute_zkvyper(args)?;
     result
         .failure()
-        .stderr(predicate::str::contains("arguments are required"));
+        .stderr(predicate::str::contains("No input files provided"));
 
     Ok(())
 }

--- a/tests/cli/metadata_hash.rs
+++ b/tests/cli/metadata_hash.rs
@@ -39,7 +39,7 @@ fn run_only_with_metadata_hash_option() -> anyhow::Result<()> {
     let result = cli::execute_zkvyper(args)?;
     result
         .failure()
-        .stderr(predicate::str::contains("arguments are required"));
+        .stderr(predicate::str::contains("No input files provided"));
 
     Ok(())
 }

--- a/tests/cli/optimization.rs
+++ b/tests/cli/optimization.rs
@@ -30,7 +30,7 @@ fn test_optimization_missing_contract() -> anyhow::Result<()> {
         let result = cli::execute_zkvyper(args)?;
 
         result.failure().stderr(predicate::str::contains(
-            "the following arguments are required",
+            "No input files provided",
         ));
     }
 

--- a/tests/cli/optimization.rs
+++ b/tests/cli/optimization.rs
@@ -29,9 +29,9 @@ fn test_optimization_missing_contract() -> anyhow::Result<()> {
         let args = &[opt_param.as_str()];
         let result = cli::execute_zkvyper(args)?;
 
-        result.failure().stderr(predicate::str::contains(
-            "No input files provided",
-        ));
+        result
+            .failure()
+            .stderr(predicate::str::contains("No input files provided"));
     }
 
     Ok(())


### PR DESCRIPTION
# What ❔

When no files provided, the error code is now 1.

## Why ❔

It used to be 0, and it didn't match neither `vyper` nor other mainstream compilers.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
