### PR TITLE
ci: add special workflow to regenerate ccache

### DIFF
--- a/.github/workflows/ccache-regen.yaml
+++ b/.github/workflows/ccache-regen.yaml
@@ -1,0 +1,90 @@
+name: Ccache regen
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 20 * * *' # each day at 8 PM GMT
+
+# Cancel the workflow if any new changes pushed to a feature branch or the trunk
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  cleanup-ccache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Clean up cache
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh cache list
+          gh cache delete --all || true
+  regen-ccache:
+    needs: cleanup-ccache
+    strategy:
+      fail-fast: false # finalize testing of all targets even if one failed
+      matrix:
+        include:
+          - name: "MacOS x86"
+            runner: macos-12-large
+          - name: "MacOS arm64"
+            runner: [self-hosted, macOS, ARM64]
+          - name: "Linux x86 gnu"
+            runner: matterlabs-ci-runner-high-performance
+            image: ghcr.io/matter-labs/zksync-llvm-runner:latest
+            target: "x86_64-unknown-linux-gnu"
+          - name: "Linux ARM64 gnu"
+            runner: matterlabs-ci-runner-arm
+            image: ghcr.io/matter-labs/zksync-llvm-runner:latest
+            target: "aarch64-unknown-linux-gnu"
+          - name: "Linux x86 musl"
+            runner: matterlabs-ci-runner-high-performance
+            image: ghcr.io/matter-labs/zksync-llvm-runner:latest
+            target: "x86_64-unknown-linux-musl"
+          - name: "Linux ARM64 musl"
+            runner: matterlabs-ci-runner-arm
+            image: ghcr.io/matter-labs/zksync-llvm-runner:latest
+            target: "aarch64-unknown-linux-musl"
+          - name: "Windows"
+            runner: windows-2022-github-hosted-16core
+            target: "x86_64-pc-windows-gnu"
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ${{ matrix.image || '' }} # Special workaround to allow matrix builds with optional container
+    name: ${{ matrix.name }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Prepare Windows env
+        if: runner.os == 'Windows'
+        uses: matter-labs/era-compiler-ci/.github/actions/prepare-msys@v1
+
+      - name: Build LLVM for tests
+        uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
+        with:
+          target-env: ${{ contains(matrix.target, 'musl') && 'musl' || 'gnu' }}
+          enable-assertions: 'true'
+          build-type: RelWithDebInfo
+          save-ccache: 'false'
+          ccache-key: ${{ format('llvm-{0}-{1}-{2}', runner.os, runner.arch, contains(matrix.target, 'musl') && 'musl' || 'gnu') }}
+
+      - name: Delete libstdc++a
+        if: runner.os == 'Windows'
+        shell: 'msys2 {0}'
+        run: rm -f target-llvm/target-final/lib/libstdc++.a
+
+      - name: Build LLVM for releases
+        uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@v1
+        with:
+          target-env: ${{ contains(matrix.target, 'musl') && 'musl' || 'gnu' }}
+          enable-assertions: 'false'
+          build-type: Release
+          save-ccache: 'true'
+          clone-llvm: 'false'
+          ccache-key: ${{ format('llvm-{0}-{1}-{2}', runner.os, runner.arch, contains(matrix.target, 'musl') && 'musl' || 'gnu') }}

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -50,6 +50,8 @@ jobs:
         with:
           enable-assertions: 'true'
           build-type: RelWithDebInfo
+          ccache-key: ${{ format('llvm-{0}-{1}-gnu', runner.os, runner.arch) }}
+          save-ccache: 'false'
 
       - name: Run tests
         uses: matter-labs/era-compiler-ci/.github/actions/rust-unit-tests@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,6 +107,9 @@ jobs:
         with:
           target-env: ${{ contains(matrix.target, 'musl') && 'musl' || 'gnu' }}
           enable-assertions: 'false'
+          build-type: Release
+          ccache-key: ${{ format('llvm-{0}-{1}-{2}', runner.os, runner.arch, contains(matrix.target, 'musl') && 'musl' || 'gnu') }}
+          save-ccache: 'false'
 
       - name: Build zkvyper
         uses: ./.github/actions/build

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -40,6 +40,8 @@ jobs:
           enable-assertions: 'true'
           build-type: RelWithDebInfo
           sanitizer: ${{ inputs.llvm-sanitizer || 'Address' }}
+          ccache-key: ${{ format('llvm-{0}-{1}-gnu', runner.os, runner.arch) }}
+          save-ccache: 'false'
 
       - name: Run tests
         uses: matter-labs/era-compiler-ci/.github/actions/rust-unit-tests@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,9 @@ jobs:
         with:
           target-env: 'gnu'
           enable-assertions: 'false'
+          build-type: Release
+          ccache-key: ${{ format('llvm-{0}-{1}-gnu', runner.os, runner.arch) }}
+          save-ccache: 'false'
 
       - name: Cargo checks
         uses: matter-labs/era-compiler-ci/.github/actions/cargo-check@v1
@@ -92,6 +95,8 @@ jobs:
           target-env: ${{ contains(matrix.target, 'musl') && 'musl' || 'gnu' }}
           enable-assertions: 'true'
           build-type: RelWithDebInfo
+          ccache-key: ${{ format('llvm-{0}-{1}-{2}', runner.os, runner.arch, contains(matrix.target, 'musl') && 'musl' || 'gnu') }}
+          save-ccache: 'false'
 
       - name: Run tests
         uses: matter-labs/era-compiler-ci/.github/actions/rust-unit-tests@v1


### PR DESCRIPTION
# What ❔

Rework the way we generate `ccache`.
* [x] Add new special workflow to daily regenerate `ccache`
* [x] `ccache` will be saved for two LLVM builds - `RelWithDebInfo` with assertions enabled that is used in tests + `Release` with assertions disabled that is used for release generation
* [x] All other builds will just use the regenerated `ccache`, no more specific conditions 

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

This will simplify `ccache` regeneration and always take into account all new changes in the builder, env variables, build types, etc. LLVM will be cached and up to date each day for testing in PRs and new release generations.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
