### PR TITLE
ci: use custom tag in binary names for manual releases

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -56,11 +56,10 @@ runs:
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       run: |
         mkdir -p ./releases/${{ inputs.release-suffix }}
-        [ ! -z "$GITHUB_REF_NAME" ] && TAG_SUFFIX="-v${GITHUB_REF_NAME}"
         [ "$RUNNER_OS" = "Windows" ] && WIN_SUFFIX=".exe"
         strip "./target/${{ matrix.target }}/${{ inputs.build-type }}/zkvyper${WIN_SUFFIX}"
         mv "./target/${{ matrix.target }}/${{ inputs.build-type }}/zkvyper${WIN_SUFFIX}" \
-          "./releases/${{ inputs.release-suffix }}/zkvyper-${{ inputs.release-suffix }}${TAG_SUFFIX}${WIN_SUFFIX}"
+          "./releases/${{ inputs.release-suffix }}/zkvyper-${{ inputs.release-suffix }}${WIN_SUFFIX}"
 
     - name: Upload binary
       if: inputs.release-suffix != ''

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,7 +115,7 @@ jobs:
         uses: ./.github/actions/build
         with:
           target: ${{ matrix.target }}
-          release-suffix: ${{ matrix.release-suffix }}
+          release-suffix: ${{ format('{0}-{1}', matrix.release-suffix, inputs.prerelease_suffix || format('v{0}', github.ref_name)) }}
 
   prepare-release:
     name: Prepare release


### PR DESCRIPTION
# What ❔

Use custom tag in binary names for manual releases instead of branch names.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To have binaries with short and beautiful names for manual pre-releases.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
