### PR TITLE
fix: the universal binary pre-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -173,18 +173,29 @@ jobs:
             exit 1
           fi
 
-      - name: Prepare universal macos binary
-        if: github.ref_type == 'tag' || (inputs.release_macos_amd64 && inputs.release_macos_arm64)
+      - name: Prepare universal MacOS binary (pre-release)
+        if: github.ref_type != 'tag' && github.event_name == 'workflow_dispatch' && inputs.release_macos_amd64 && inputs.release_macos_arm64
         env:
           MACOSX_UNIVERSAL_SUFFIX: "macosx"
         run: |
           OUTDIR="./releases/release-${MACOSX_UNIVERSAL_SUFFIX}/${MACOSX_UNIVERSAL_SUFFIX}"
           mkdir -p "${OUTDIR}"
-          [ ! -z "$GITHUB_REF_NAME" ] && TAG_SUFFIX="-v${GITHUB_REF_NAME}"
-          OUTPUT="${OUTDIR}/zkvyper-${MACOSX_UNIVERSAL_SUFFIX}${TAG_SUFFIX}"
+          OUTPUT="${OUTDIR}/zkvyper-${MACOSX_UNIVERSAL_SUFFIX}-${{ github.event.inputs.prerelease_suffix }}"
           llvm-lipo -create -output "${OUTPUT}" \
-            ./releases/release-macosx-amd64/macosx-amd64/zkvyper-macosx-amd64${TAG_SUFFIX} \
-            ./releases/release-macosx-arm64/macosx-arm64/zkvyper-macosx-arm64${TAG_SUFFIX}
+            ./releases/release-macosx-amd64-${{ github.event.inputs.prerelease_suffix }}/macosx-amd64-${{ github.event.inputs.prerelease_suffix }}/zkvyper-macosx-amd64-${{ github.event.inputs.prerelease_suffix }} \
+            ./releases/release-macosx-arm64-${{ github.event.inputs.prerelease_suffix }}/macosx-arm64-${{ github.event.inputs.prerelease_suffix }}/zkvyper-macosx-arm64-${{ github.event.inputs.prerelease_suffix }}
+
+      - name: Prepare universal MacOS binary (release)
+        if: github.ref_type == 'tag'
+        env:
+          MACOSX_UNIVERSAL_SUFFIX: "macosx"
+        run: |
+          OUTDIR="./releases/release-${MACOSX_UNIVERSAL_SUFFIX}/${MACOSX_UNIVERSAL_SUFFIX}"
+          mkdir -p "${OUTDIR}"
+          OUTPUT="${OUTDIR}/zkvyper-${MACOSX_UNIVERSAL_SUFFIX}-v${GITHUB_REF_NAME}"
+          llvm-lipo -create -output "${OUTPUT}" \
+            ./releases/release-macosx-amd64/macosx-amd64/zkvyper-macosx-amd64-v${GITHUB_REF_NAME} \
+            ./releases/release-macosx-arm64/macosx-arm64/zkvyper-macosx-arm64-v${GITHUB_REF_NAME}
 
       - name: Prepare release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
# What ❔

Fixes the universal binary pre-release.

# Why ❔

It was broken when switching to custom tag suffixes.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
