### PR TITLE
fix: fragile LLVM options parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - The error code when no input files are provided
+- Several issues with fragile parsing of `--llvm-options`
 
 ## [1.5.4] - 2024-08-27
 

--- a/src/zkvyper/arguments.rs
+++ b/src/zkvyper/arguments.rs
@@ -45,6 +45,8 @@ pub struct Arguments {
     pub fallback_to_optimizing_for_size: bool,
 
     /// Pass arbitary space-separated options to LLVM.
+    /// The argument must be a single quoted string following a `=` separator.
+    /// Example: `--llvm-options='-eravm-jump-table-density-threshold=10'`.
     #[structopt(long = "llvm-options")]
     pub llvm_options: Option<String>,
 

--- a/src/zkvyper/main.rs
+++ b/src/zkvyper/main.rs
@@ -110,7 +110,12 @@ fn main_inner() -> anyhow::Result<()> {
     let llvm_options: Vec<String> = arguments
         .llvm_options
         .as_ref()
-        .map(|options| options.split(' ').map(|option| option.to_owned()).collect())
+        .map(|options| {
+            options
+                .split_whitespace()
+                .map(|option| option.to_owned())
+                .collect()
+        })
         .unwrap_or_default();
 
     let vyper_optimizer_enabled = !arguments.disable_vyper_optimizer;

--- a/tests/cli/llvm_options.rs
+++ b/tests/cli/llvm_options.rs
@@ -1,0 +1,17 @@
+use crate::{cli, common};
+use predicates::prelude::*;
+
+#[test]
+fn run_zkvyper_with_llvm_options() -> anyhow::Result<()> {
+    let _ = common::setup();
+    let args = &[
+        cli::TEST_VYPER_CONTRACT_PATH,
+        "--llvm-options='-eravm-disable-system-request-memoization 10'",
+    ];
+
+    // Execute zkvyper command
+    let result = cli::execute_zkvyper(args)?;
+    result.success().stdout(predicate::str::contains("0x"));
+
+    Ok(())
+}

--- a/tests/cli/mod.rs
+++ b/tests/cli/mod.rs
@@ -16,6 +16,7 @@ mod fallback;
 mod format;
 mod llvm_debug_log;
 mod llvm_ir;
+mod llvm_options;
 mod llvm_verify_each;
 mod metadata_hash;
 mod optimization;


### PR DESCRIPTION
# What ❔

Adds more resilience to `--llvm-options` parsing, and makes `--help` more informative.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
