### PR TITLE
fix: the broken --version endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#7de0c55b51bf0bab90624413665f97697eeea55b"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#23bd5c502ab9d246c44ed61802153de47a7d9dfd"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -880,9 +880,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1338,9 +1338,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "7b8cefcf97f41316955f9294cd61f639bdcfa9f2f230faac6cb896aa8ab64704"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -1379,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
@@ -1596,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2736,8 +2736,9 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zkevm_opcode_defs"
-version = "0.150.5"
-source = "git+https://github.com/matter-labs/zksync-protocol#9bf5cf839f76a19f7c21981d8c56a7f8bbe03d7e"
+version = "0.150.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "762b5f1c1b283c5388995a85d40a05aef1c14f50eb904998b7e9364739f5b899"
 dependencies = [
  "bitflags 2.6.0",
  "blake2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ semver = { version = "=1.0.23", features = [ "serde" ] }
 lazy_static = "=1.5.0"
 hex = "=0.4.3"
 
-zkevm_opcode_defs = { git = "https://github.com/matter-labs/zksync-protocol", version = "=0.150.5" }
+zkevm_opcode_defs = "=0.150.6"
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }

--- a/src/zkvyper/arguments.rs
+++ b/src/zkvyper/arguments.rs
@@ -156,10 +156,14 @@ impl Arguments {
             }
         }
 
-        if self.version && std::env::args().count() > 2 {
-            anyhow::bail!(
-                "Error: No other options are allowed while getting the compiler version."
-            );
+        if self.version {
+            if std::env::args().count() > 2 {
+                anyhow::bail!(
+                    "Error: No other options are allowed while getting the compiler version."
+                );
+            } else {
+                return Ok(());
+            }
         }
 
         if self.input_paths.is_empty() {

--- a/tests/cli/mod.rs
+++ b/tests/cli/mod.rs
@@ -23,6 +23,7 @@ mod optimization;
 mod output_dir;
 mod overwrite;
 mod supress;
+mod version;
 mod vyper;
 
 /// The solidity contract name

--- a/tests/cli/version.rs
+++ b/tests/cli/version.rs
@@ -1,0 +1,30 @@
+use crate::{cli, common};
+use predicates::prelude::*;
+
+#[test]
+fn test_version() -> anyhow::Result<()> {
+    let _ = common::setup();
+
+    let args = &["--version"];
+    let result = cli::execute_zkvyper(args)?;
+
+    result
+        .success()
+        .stdout(predicate::str::contains("Vyper compiler for ZKsync"));
+
+    Ok(())
+}
+
+#[test]
+fn test_version_with_extra_args() -> anyhow::Result<()> {
+    let _ = common::setup();
+
+    let args = &["--version", cli::TEST_VYPER_CONTRACT_PATH];
+    let result = cli::execute_zkvyper(args)?;
+
+    result.failure().stderr(predicate::str::contains(
+        "Error: No other options are allowed while getting the compiler version.",
+    ));
+
+    Ok(())
+}


### PR DESCRIPTION
# What ❔

Fixes the broken `zkvyper --version` endpoint.

## Why ❔

It was regressed after more argument validations were added.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
