### PR TITLE
feat: wrap project metadata into extra data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # The `zkvyper` changelog
 
+## [Unreleased]
+
+### Changed
+
+- Wrapped project metadata into another object for future extensibility
+
 ## [1.5.6] - 2024-10-16
 
 ### Fixed

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 
 use normpath::PathExt;
 
+use crate::vyper::combined_json::extra_data::ExtraData as CombinedJsonExtraData;
 use crate::vyper::combined_json::CombinedJson;
 use crate::vyper::selection::Selection as VyperSelection;
 use crate::vyper::Compiler as VyperCompiler;
@@ -142,6 +143,8 @@ impl Build {
             })
             .collect();
 
-        CombinedJson::new(contracts, version, self.project_metadata, zkvyper_version)
+        let extra_data = CombinedJsonExtraData::new(self.project_metadata);
+
+        CombinedJson::new(contracts, extra_data, version, zkvyper_version)
     }
 }

--- a/src/vyper/combined_json/extra_data.rs
+++ b/src/vyper/combined_json/extra_data.rs
@@ -1,0 +1,21 @@
+//!
+//! Extra data for combined JSON output.
+//!
+
+///
+/// Extra data for combined JSON output.
+///
+#[derive(Debug, serde::Serialize)]
+pub struct ExtraData {
+    /// The project metadata.
+    pub project_metadata: serde_json::Value,
+}
+
+impl ExtraData {
+    ///
+    /// A shortcut constructor.
+    ///
+    pub fn new(project_metadata: serde_json::Value) -> Self {
+        Self { project_metadata }
+    }
+}

--- a/src/vyper/combined_json/mod.rs
+++ b/src/vyper/combined_json/mod.rs
@@ -3,6 +3,7 @@
 //!
 
 pub mod contract;
+pub mod extra_data;
 
 use std::collections::BTreeMap;
 use std::fs::File;
@@ -10,6 +11,7 @@ use std::io::Write;
 use std::path::Path;
 
 use self::contract::Contract;
+use self::extra_data::ExtraData;
 
 ///
 /// The `vyper --combined-json` output.
@@ -19,12 +21,11 @@ pub struct CombinedJson {
     /// The contract entries.
     #[serde(flatten)]
     pub contracts: BTreeMap<String, Contract>,
+    /// The extra project data.
+    pub extra_data: ExtraData,
     /// The `vyper` compiler version.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
-
-    /// The project metadata.
-    pub project_metadata: serde_json::Value,
     /// The `zkvyper` compiler version.
     pub zk_version: String,
 }
@@ -37,14 +38,14 @@ impl CombinedJson {
     ///
     pub fn new(
         contracts: BTreeMap<String, Contract>,
+        extra_data: ExtraData,
         version: Option<&semver::Version>,
-        project_metadata: serde_json::Value,
         zk_version: &semver::Version,
     ) -> Self {
         Self {
             contracts,
+            extra_data,
             version: version.map(|version| version.to_string()),
-            project_metadata,
             zk_version: zk_version.to_string(),
         }
     }


### PR DESCRIPTION
# What ❔

In combined JSON output, wraps `project_metadata` into `extra_data`.

## Why ❔

All contract objects are flattened and raised to the root of combined JSON output.
The plugin relies on it and treats all new fields as contracts unless they are explicitly excluded like `version` and `zk_version`.
The newly added `extra_data` object will be a safe haven for all new output fields we might need in the future.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
