### PR TITLE
fix: library linking time indeterminism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#c226149995a9efd8e26d74bfa01c0da0764979fd"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#67bb2349e221627f15b09893e59f807094ab81ca"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/src/const.rs
+++ b/src/const.rs
@@ -4,6 +4,8 @@
 
 #![allow(dead_code)]
 
+use std::collections::BTreeMap;
+
 use lazy_static::lazy_static;
 
 /// The default executable name.
@@ -75,7 +77,7 @@ lazy_static! {
                 .expect("Minimal proxy target machine initialization error");
         let assembly_buffer = era_compiler_llvm_context::eravm_assemble(&target_machine, MINIMAL_PROXY_CONTRACT_NAME, MINIMAL_PROXY_CONTRACT_ASSEMBLY, None)
                 .expect("Minimal proxy assembling error");
-        let build = era_compiler_llvm_context::eravm_build(assembly_buffer, None, Some(MINIMAL_PROXY_CONTRACT_ASSEMBLY.to_owned()))
+        let build = era_compiler_llvm_context::eravm_build(assembly_buffer, &BTreeMap::new(), None, Some(MINIMAL_PROXY_CONTRACT_ASSEMBLY.to_owned()))
                 .expect("Minimal proxy building error");
         build.bytecode
     };

--- a/src/project/contract/eravm_assembly.rs
+++ b/src/project/contract/eravm_assembly.rs
@@ -2,6 +2,8 @@
 //! The EraVM assembly contract.
 //!
 
+use std::collections::BTreeMap;
+
 use crate::build::contract::Contract as ContractBuild;
 use crate::message_type::MessageType;
 use crate::vyper::selection::Selection as VyperSelection;
@@ -56,6 +58,7 @@ impl Contract {
 
         let build = era_compiler_llvm_context::eravm_build(
             bytecode_buffer,
+            &BTreeMap::new(),
             metadata_hash,
             Some(self.source_code),
         )?;

--- a/src/project/contract/llvm_ir.rs
+++ b/src/project/contract/llvm_ir.rs
@@ -2,6 +2,8 @@
 //! The LLVM IR contract.
 //!
 
+use std::collections::BTreeMap;
+
 use crate::build::contract::Contract as ContractBuild;
 use crate::message_type::MessageType;
 use crate::vyper::selection::Selection as VyperSelection;
@@ -57,6 +59,7 @@ impl Contract {
 
         let build = context.build(
             contract_path,
+            &BTreeMap::new(),
             metadata_hash,
             output_selection.contains(&VyperSelection::EraVMAssembly),
             false,

--- a/src/project/contract/vyper/mod.rs
+++ b/src/project/contract/vyper/mod.rs
@@ -227,6 +227,7 @@ impl Contract {
         let is_minimal_proxy_used = context.vyper().is_minimal_proxy_used();
         let mut build = context.build(
             contract_path,
+            &BTreeMap::new(),
             metadata_hash,
             output_selection.contains(&VyperSelection::EraVMAssembly),
             false,
@@ -376,9 +377,5 @@ impl era_compiler_llvm_context::Dependency for DependencyData {
 
     fn resolve_path(&self, _identifier: &str) -> anyhow::Result<String> {
         anyhow::bail!("Dependency mechanism is not available in Vyper");
-    }
-
-    fn resolve_library(&self, _path: &str) -> Option<String> {
-        None
     }
 }


### PR DESCRIPTION
# What ❔

Fixes the library linking indeterminism.

## Why ❔

The bytecode is not equal depending on when libraries are linked: at compile time or deploy (post-compile) time.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
