### PR TITLE
chore: move code segment to era-compiler-common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # The `zkvyper` changelog
 
+## [Unreleased]
+
+### Changed
+
+- Updated to Rust v1.82.0
+
 ## [1.5.7] - 2024-10-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 [[package]]
 name = "era-compiler-common"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#11cc7ed039fb96ef04d45d71c009e8dc8fffda9a"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#32637b83bf23b7b177c7d711992a6f6f101ac399"
 dependencies = [
  "anyhow",
  "base58",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-downloader"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#11cc7ed039fb96ef04d45d71c009e8dc8fffda9a"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#32637b83bf23b7b177c7d711992a6f6f101ac399"
 dependencies = [
  "anyhow",
  "colored",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#67bb2349e221627f15b09893e59f807094ab81ca"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#5350b284c14ff19309d02c9c38a0fe88c93e037b"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -995,7 +995,7 @@ source = "git+https://github.com/matter-labs-forks/inkwell?branch=llvm-17#c50692
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -1359,7 +1359,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -1917,7 +1917,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -2126,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.85"
+version = "2.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+checksum = "e89275301d38033efb81a6e60e3497e734dfcc62571f2854bf4b16690398824c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2198,22 +2198,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
+checksum = "5d171f59dbaa811dbbb1aee1e73db92ec2b122911a48e1390dfe327a821ddede"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
+checksum = "b08be0f17bd307950653ce45db00cd31200d82b624b36e181337d9c7d92765b5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]
@@ -2458,7 +2458,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
  "wasm-bindgen-shared",
 ]
 
@@ -2492,7 +2492,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2725,7 +2725,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.86",
 ]
 
 [[package]]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.80.1"
+channel = "1.82.0"

--- a/src/project/contract/vyper/expression/instruction/mod.rs
+++ b/src/project/contract/vyper/expression/instruction/mod.rs
@@ -1076,13 +1076,13 @@ impl Instruction {
                 let arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
 
                 match context
-                    .code_type()
+                    .code_segment()
                     .ok_or_else(|| anyhow::anyhow!("The contract code part type is undefined"))?
                 {
-                    era_compiler_llvm_context::CodeType::Deploy => {
+                    era_compiler_common::CodeSegment::Deploy => {
                         Ok(Some(context.field_const(0).as_basic_value_enum()))
                     }
-                    era_compiler_llvm_context::CodeType::Runtime => {
+                    era_compiler_common::CodeSegment::Runtime => {
                         era_compiler_llvm_context::eravm_evm_calldata::load(
                             context,
                             arguments[0].into_int_value(),
@@ -1093,13 +1093,13 @@ impl Instruction {
             }
             Self::CALLDATASIZE => {
                 match context
-                    .code_type()
+                    .code_segment()
                     .ok_or_else(|| anyhow::anyhow!("The contract code part type is undefined"))?
                 {
-                    era_compiler_llvm_context::CodeType::Deploy => {
+                    era_compiler_common::CodeSegment::Deploy => {
                         Ok(Some(context.field_const(0).as_basic_value_enum()))
                     }
-                    era_compiler_llvm_context::CodeType::Runtime => {
+                    era_compiler_common::CodeSegment::Runtime => {
                         era_compiler_llvm_context::eravm_evm_calldata::size(context).map(Some)
                     }
                 }
@@ -1108,13 +1108,13 @@ impl Instruction {
                 let arguments = Self::translate_arguments_llvm::<D, 3>(arguments, context)?;
 
                 let source_offset = match context
-                    .code_type()
+                    .code_segment()
                     .ok_or_else(|| anyhow::anyhow!("The contract code part type is undefined"))?
                 {
-                    era_compiler_llvm_context::CodeType::Deploy => {
+                    era_compiler_common::CodeSegment::Deploy => {
                         era_compiler_llvm_context::eravm_evm_calldata::size(context)?
                     }
-                    era_compiler_llvm_context::CodeType::Runtime => {
+                    era_compiler_common::CodeSegment::Runtime => {
                         arguments[1].into_int_value().as_basic_value_enum()
                     }
                 }
@@ -1132,17 +1132,17 @@ impl Instruction {
             Self::DLOAD(arguments) => {
                 let arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
 
-                match context.code_type() {
+                match context.code_segment() {
                     None => {
                         panic!("code part is undefined");
                     }
-                    Some(era_compiler_llvm_context::CodeType::Deploy) => {
+                    Some(era_compiler_common::CodeSegment::Deploy) => {
                         era_compiler_llvm_context::eravm_evm_calldata::load(
                             context,
                             arguments[0].into_int_value(),
                         )
                     }
-                    Some(era_compiler_llvm_context::CodeType::Runtime) => {
+                    Some(era_compiler_common::CodeSegment::Runtime) => {
                         era_compiler_llvm_context::eravm_evm_immutable::load(
                             context,
                             arguments[0].into_int_value(),
@@ -1154,13 +1154,13 @@ impl Instruction {
             Self::DLOADBYTES(arguments) => {
                 let arguments = Self::translate_arguments_llvm::<D, 3>(arguments, context)?;
 
-                match context.code_type() {
+                match context.code_segment() {
                     None => {
                         anyhow::bail!(
                             "Immutables are not available if the contract part is undefined"
                         );
                     }
-                    Some(era_compiler_llvm_context::CodeType::Deploy) => {
+                    Some(era_compiler_common::CodeSegment::Deploy) => {
                         era_compiler_llvm_context::eravm_evm_calldata::copy(
                             context,
                             arguments[0].into_int_value(),
@@ -1168,7 +1168,7 @@ impl Instruction {
                             arguments[2].into_int_value(),
                         )
                     }
-                    Some(era_compiler_llvm_context::CodeType::Runtime) => immutable::load_bytes(
+                    Some(era_compiler_common::CodeSegment::Runtime) => immutable::load_bytes(
                         context,
                         arguments[0].into_int_value(),
                         arguments[1].into_int_value(),
@@ -1180,13 +1180,13 @@ impl Instruction {
 
             Self::CODESIZE => {
                 match context
-                    .code_type()
+                    .code_segment()
                     .ok_or_else(|| anyhow::anyhow!("The contract code part type is undefined"))?
                 {
-                    era_compiler_llvm_context::CodeType::Deploy => {
+                    era_compiler_common::CodeSegment::Deploy => {
                         era_compiler_llvm_context::eravm_evm_calldata::size(context).map(Some)
                     }
-                    era_compiler_llvm_context::CodeType::Runtime => {
+                    era_compiler_common::CodeSegment::Runtime => {
                         let code_source =
                             era_compiler_llvm_context::eravm_general::code_source(context)?;
                         era_compiler_llvm_context::eravm_evm_ext_code::size(
@@ -1198,8 +1198,8 @@ impl Instruction {
                 }
             }
             Self::CODECOPY(arguments) => {
-                if let era_compiler_llvm_context::CodeType::Runtime = context
-                    .code_type()
+                if let era_compiler_common::CodeSegment::Runtime = context
+                    .code_segment()
                     .ok_or_else(|| anyhow::anyhow!("The contract code part type is undefined"))?
                 {
                     anyhow::bail!(

--- a/src/project/contract/vyper/mod.rs
+++ b/src/project/contract/vyper/mod.rs
@@ -324,39 +324,31 @@ where
             .extract_functions()?
             .into_iter()
             .map(|(label, expression)| {
-                (
-                    label,
-                    expression,
-                    era_compiler_llvm_context::CodeType::Deploy,
-                )
+                (label, expression, era_compiler_common::CodeSegment::Deploy)
             })
-            .collect::<Vec<(String, Expression, era_compiler_llvm_context::CodeType)>>();
+            .collect::<Vec<(String, Expression, era_compiler_common::CodeSegment)>>();
         function_expressions.extend(
             runtime_code
                 .extract_functions()?
                 .into_iter()
                 .map(|(label, expression)| {
-                    (
-                        label,
-                        expression,
-                        era_compiler_llvm_context::CodeType::Runtime,
-                    )
+                    (label, expression, era_compiler_common::CodeSegment::Runtime)
                 })
-                .collect::<Vec<(String, Expression, era_compiler_llvm_context::CodeType)>>(),
+                .collect::<Vec<(String, Expression, era_compiler_common::CodeSegment)>>(),
         );
 
         let mut functions = Vec::with_capacity(function_expressions.capacity());
-        for (label, expression, code_type) in function_expressions.into_iter() {
+        for (label, expression, code_segment) in function_expressions.into_iter() {
             functions.push((
                 Function::new(Expression::safe_label(label.as_str()), expression),
-                code_type,
+                code_segment,
             ));
         }
-        for (function, _code_type) in functions.iter_mut() {
+        for (function, _code_segment) in functions.iter_mut() {
             function.declare(context)?;
         }
-        for (function, code_type) in functions.into_iter() {
-            context.set_code_type(code_type);
+        for (function, code_segment) in functions.into_iter() {
+            context.set_code_segment(code_segment);
             function.into_llvm(context)?;
         }
 


### PR DESCRIPTION
# What ❔

Uses contract code segment that was moved to [era-compiler-common](https://github.com/matter-labs/era-compiler-common).

## Why ❔

It is required for some LLVM-independent crates such as the upcoming era-solc client.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
