### PR TITLE
ci: update cargo deny config and enable PR tests for all files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,9 +4,6 @@ name: Tests
 on:
   workflow_dispatch:
   pull_request:
-    paths-ignore:
-      - '.gitignore'
-      - '**/*.md'
   push:
     branches:
       - main

--- a/deny.toml
+++ b/deny.toml
@@ -1,17 +1,10 @@
-all-features = false
-no-default-features = false
-
 [advisories]
-vulnerability = "deny"
-unmaintained = "warn"
 yanked = "warn"
-notice = "warn"
 ignore = [
     #"RUSTSEC-0000-0000",
 ]
 
 [licenses]
-unlicensed = "deny"
 allow = [
     #"Apache-2.0 WITH LLVM-exception",
     "MIT",
@@ -20,17 +13,12 @@ allow = [
     "Unlicense",
     "MPL-2.0",
     "Unicode-DFS-2016",
+    "Unicode-3.0",
     "CC0-1.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
     "Zlib",
 ]
-deny = [
-    #"Nokia",
-]
-copyleft = "warn"
-allow-osi-fsf-free = "neither"
-default = "deny"
 confidence-threshold = 0.8
 exceptions = [
     # Each entry is the crate and version constraint, and its specific allow


### PR DESCRIPTION
# What ❔

* [x] Update cargo deny config
* [x] Enable PR tests for all files

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To fix cargo deny license warnings and errors and make sure `required` check condition is always fullfilled.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
