### PR TITLE
fix: remove the branch replacing call(0x04) with memcopy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Calls to precompile `0x04` are not replaced with `memcopy` anymore
 - Cleared return data after calling `CREATE`/`CREATE2`
 
 ## [1.5.7] - 2024-10-31

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-identity-precompile-no-memcopy#3068d634773ec2074b9baf98be694d45782a17dc"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#0902a3c9e777e1f3b22ad54c81f1a74f475a375c"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#d4f348effd94e6fba0983a1378346f264a47864e"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-identity-precompile-no-memcopy#3068d634773ec2074b9baf98be694d45782a17dc"
 dependencies = [
  "anyhow",
  "era-compiler-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ hex = "=0.4.3"
 zkevm_opcode_defs = "=0.150.6"
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-identity-precompile-no-memcopy" }
 
 [dev-dependencies]
 assert_cmd = "=2.0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ hex = "=0.4.3"
 zkevm_opcode_defs = "=0.150.6"
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-identity-precompile-no-memcopy" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 
 [dev-dependencies]
 assert_cmd = "=2.0.16"


### PR DESCRIPTION
Removes the branch replacing call(0x04) with memcopy.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
