### PR TITLE
chore: add v prefix to documentation website url

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Deploy
         uses: matter-labs/deploy-mdbooks@v1
         with:
-          version: ${{ inputs.version || github.ref_name }}
+          version: ${{ inputs.version || format('v{0}', github.ref_name) }}
           docs-dir: ${{ inputs.docs-dir || 'docs' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           enable-tests: true


### PR DESCRIPTION
# What ❔

Add `v` prefix to documentation website url.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To make docs url more beautiful `/v1.5.8` instead of `/1.5.8`.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
