### PR TITLE
ci: add binaries attestation support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,6 +131,10 @@ jobs:
           release-suffix: ${{ format('{0}-{1}', matrix.release-suffix, inputs.prerelease_suffix || format('v{0}', github.ref_name)) }}
 
   prepare-release:
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
     name: Prepare release
     runs-on: matterlabs-ci-runner-high-performance
     container:
@@ -198,6 +202,12 @@ jobs:
           llvm-lipo -create -output "${OUTPUT}" \
             ./releases/release-macosx-amd64-${RELEASE_SUFFIX}/macosx-amd64-${RELEASE_SUFFIX}/zkvyper-macosx-amd64-${RELEASE_SUFFIX} \
             ./releases/release-macosx-arm64-${RELEASE_SUFFIX}/macosx-arm64-${RELEASE_SUFFIX}/zkvyper-macosx-arm64-${RELEASE_SUFFIX}
+
+      - name: Binaries attestation
+        uses: actions/attest-build-provenance@v2
+        if: github.ref_type == 'tag'
+        with:
+          subject-path: 'releases/**/**'
 
       - name: Prepare release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
# What ❔

Add compiler binaries [GitHub attestations ](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds)support.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

It would allow binary users to use attestation information through `gh api` to check if compiler binaries were built in our repositories and by our workflows improving usage security.

Attestation example: https://github.com/matter-labs/era-compiler-solidity/attestations/4282238


<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
