### PR TITLE
fix(evm): remove the old dependency handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,11 +67,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
@@ -174,9 +175,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bitvec"
@@ -289,9 +290,9 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.2.7"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "shlex",
 ]
@@ -344,7 +345,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -399,9 +400,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -433,9 +434,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-bigint"
@@ -461,15 +462,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1559b6cba622276d6d63706db152618eeb15b89b3e4041446b05876e352e639"
+checksum = "5b16d9d0d88a5273d830dac8b78ceb217ffc9b1d5404e5597a3542515329405b"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -477,12 +478,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332d754c0af53bc87c108fed664d121ecf59207ec4196041f04d6ab9002ad33f"
+checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -531,7 +532,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -627,7 +628,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1846-support-libraries-in-the-evm-linker#1e5a3eef3136d0c91a23efd1f6e8d732093c0b67"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#de72ad122ac3cd0f24a76eee889d08c85cc98f33"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -1118,7 +1119,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1177,14 +1178,14 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1193,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "inkwell"
 version = "0.4.0"
-source = "git+https://github.com/matter-labs-forks/inkwell?branch=az-cpr-1846-support-libraries-in-the-evm-linker#21b3e07a5cf4b7920d2e7f56e7c48b2d1779cc18"
+source = "git+https://github.com/matter-labs-forks/inkwell?branch=llvm-17#b6c1bf7e730d99a8a1e2acf7513befcf80466ba7"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -1208,11 +1209,11 @@ dependencies = [
 [[package]]
 name = "inkwell_internals"
 version = "0.9.0"
-source = "git+https://github.com/matter-labs-forks/inkwell?branch=az-cpr-1846-support-libraries-in-the-evm-linker#21b3e07a5cf4b7920d2e7f56e7c48b2d1779cc18"
+source = "git+https://github.com/matter-labs-forks/inkwell?branch=llvm-17#b6c1bf7e730d99a8a1e2acf7513befcf80466ba7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1240,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1267,9 +1268,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1326,7 +1327,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "libc",
  "redox_syscall",
 ]
@@ -1346,7 +1347,7 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 [[package]]
 name = "llvm-sys"
 version = "170.0.1"
-source = "git+https://github.com/matter-labs-forks/llvm-sys.rs?branch=az-cpr-1846-support-libraries-in-the-evm-linker#00c474ab3766d4b70909c042b0b817612791f996"
+source = "git+https://github.com/matter-labs-forks/llvm-sys.rs?branch=llvm-17.0#5dad04e81f806046e383ee73a8d1b9ed53161624"
 dependencies = [
  "anyhow",
  "cc",
@@ -1368,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "memchr"
@@ -1395,9 +1396,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -1571,7 +1572,7 @@ version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1588,14 +1589,14 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
@@ -1801,9 +1802,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -1897,7 +1898,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -2009,11 +2010,11 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustix"
-version = "0.38.43"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2028,6 +2029,12 @@ checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -2070,7 +2077,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2122,7 +2129,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2319,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.95"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2342,7 +2349,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2409,7 +2416,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2420,28 +2427,28 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
  "test-case-core",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2569,9 +2576,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
 
 [[package]]
 name = "unsigned-varint"
@@ -2652,34 +2659,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2690,9 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2700,28 +2708,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2889,9 +2900,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.22"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]
@@ -2953,7 +2964,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -2975,7 +2986,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2995,7 +3006,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -3024,7 +3035,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3033,7 +3044,7 @@ version = "0.150.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "762b5f1c1b283c5388995a85d40a05aef1c14f50eb904998b7e9364739f5b899"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "blake2",
  "ethereum-types",
  "k256",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,7 +627,7 @@ dependencies = [
 [[package]]
 name = "era-compiler-llvm-context"
 version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#564e41b4d9e0b6a3a0d2f875c6dd891477cef70c"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=az-cpr-1846-support-libraries-in-the-evm-linker#1e5a3eef3136d0c91a23efd1f6e8d732093c0b67"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -1193,7 +1193,7 @@ dependencies = [
 [[package]]
 name = "inkwell"
 version = "0.4.0"
-source = "git+https://github.com/matter-labs-forks/inkwell?branch=llvm-17#c5d783f52b755f5382e99e3f1179039b9435e3cc"
+source = "git+https://github.com/matter-labs-forks/inkwell?branch=az-cpr-1846-support-libraries-in-the-evm-linker#21b3e07a5cf4b7920d2e7f56e7c48b2d1779cc18"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -1208,7 +1208,7 @@ dependencies = [
 [[package]]
 name = "inkwell_internals"
 version = "0.9.0"
-source = "git+https://github.com/matter-labs-forks/inkwell?branch=llvm-17#c5d783f52b755f5382e99e3f1179039b9435e3cc"
+source = "git+https://github.com/matter-labs-forks/inkwell?branch=az-cpr-1846-support-libraries-in-the-evm-linker#21b3e07a5cf4b7920d2e7f56e7c48b2d1779cc18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1346,7 +1346,7 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 [[package]]
 name = "llvm-sys"
 version = "170.0.1"
-source = "git+https://github.com/matter-labs-forks/llvm-sys.rs?branch=llvm-17.0#b65826dfdb19676637dbddb9f01bcc52ae2c4308"
+source = "git+https://github.com/matter-labs-forks/llvm-sys.rs?branch=az-cpr-1846-support-libraries-in-the-evm-linker#00c474ab3766d4b70909c042b0b817612791f996"
 dependencies = [
  "anyhow",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ hex = "=0.4.3"
 zkevm_opcode_defs = "=0.150.6"
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-cpr-1846-support-libraries-in-the-evm-linker" }
 
 [dev-dependencies]
 assert_cmd = "=2.0.16"
@@ -46,7 +46,7 @@ era-compiler-downloader = { git = "https://github.com/matter-labs/era-compiler-c
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"
-branch = "llvm-17"
+branch = "az-cpr-1846-support-libraries-in-the-evm-linker"
 default-features = false
 features = ["llvm17-0", "no-libffi-linking", "target-eravm", "target-evm"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ hex = "=0.4.3"
 zkevm_opcode_defs = "=0.150.6"
 
 era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
-era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "az-cpr-1846-support-libraries-in-the-evm-linker" }
+era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 
 [dev-dependencies]
 assert_cmd = "=2.0.16"
@@ -46,7 +46,7 @@ era-compiler-downloader = { git = "https://github.com/matter-labs/era-compiler-c
 
 [dependencies.inkwell]
 git = "https://github.com/matter-labs-forks/inkwell"
-branch = "az-cpr-1846-support-libraries-in-the-evm-linker"
+branch = "llvm-17"
 default-features = false
 features = ["llvm17-0", "no-libffi-linking", "target-eravm", "target-evm"]
 

--- a/LLVM.lock
+++ b/LLVM.lock
@@ -1,2 +1,2 @@
 url = "https://github.com/matter-labs/era-compiler-llvm"
-branch = "v1.5.6"
+branch = "main"

--- a/src/project/contract/llvm_ir.rs
+++ b/src/project/contract/llvm_ir.rs
@@ -53,16 +53,14 @@ impl Contract {
         let module = llvm
             .create_module_from_ir(memory_buffer)
             .map_err(|error| anyhow::anyhow!(error.to_string()))?;
-        let context: era_compiler_llvm_context::EraVMContext<
-            '_,
-            era_compiler_llvm_context::DummyDependency,
-        > = era_compiler_llvm_context::EraVMContext::new(
-            &llvm,
-            module,
-            llvm_options,
-            optimizer,
-            debug_config,
-        );
+        let context: era_compiler_llvm_context::EraVMContext =
+            era_compiler_llvm_context::EraVMContext::new(
+                &llvm,
+                module,
+                llvm_options,
+                optimizer,
+                debug_config,
+            );
 
         let build = context.build(
             contract_path,

--- a/src/project/contract/vyper/expression/instruction/assert.rs
+++ b/src/project/contract/vyper/expression/instruction/assert.rs
@@ -16,14 +16,11 @@ impl Assert {
     ///
     /// Converts the entity to an LLVM value.
     ///
-    pub fn into_llvm_value<D>(
+    pub fn into_llvm_value(
         self,
-        context: &mut era_compiler_llvm_context::EraVMContext<D>,
+        context: &mut era_compiler_llvm_context::EraVMContext,
         is_unreachable: bool,
-    ) -> anyhow::Result<()>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
+    ) -> anyhow::Result<()> {
         let [condition] = self.0;
 
         let error_block = context.append_basic_block("if_error");

--- a/src/project/contract/vyper/expression/instruction/clamp.rs
+++ b/src/project/contract/vyper/expression/instruction/clamp.rs
@@ -9,16 +9,13 @@ use era_compiler_llvm_context::IContext;
 ///
 /// Translates the two-sides bounded clamp.
 ///
-pub fn ordinary<'ctx, D>(
-    context: &mut era_compiler_llvm_context::EraVMContext<'ctx, D>,
+pub fn ordinary<'ctx>(
+    context: &mut era_compiler_llvm_context::EraVMContext<'ctx>,
     operand_1: inkwell::values::IntValue<'ctx>,
     operand_2: inkwell::values::IntValue<'ctx>,
     operand_3: inkwell::values::IntValue<'ctx>,
     is_signed: bool,
-) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
-where
-    D: era_compiler_llvm_context::Dependency,
-{
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
     let error_block = context.append_basic_block("if_error");
     let join_block = context.append_basic_block("if_join");
 
@@ -60,15 +57,12 @@ where
 ///
 /// Translates the one-side bounded clamp with predicate.
 ///
-pub fn with_predicate<'ctx, D>(
-    context: &mut era_compiler_llvm_context::EraVMContext<'ctx, D>,
+pub fn with_predicate<'ctx>(
+    context: &mut era_compiler_llvm_context::EraVMContext<'ctx>,
     operand_1: inkwell::values::IntValue<'ctx>,
     operand_2: inkwell::values::IntValue<'ctx>,
     predicate: inkwell::IntPredicate,
-) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
-where
-    D: era_compiler_llvm_context::Dependency,
-{
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
     let error_block = context.append_basic_block("clamp_single_error");
     let join_block = context.append_basic_block("clamp_single_join");
 

--- a/src/project/contract/vyper/expression/instruction/create.rs
+++ b/src/project/contract/vyper/expression/instruction/create.rs
@@ -10,16 +10,13 @@ use era_compiler_llvm_context::IContext;
 /// If `input_length` is `54`, the built-in is `create_minimal_proxy_to`.
 /// If `input_length` is `143`, the built-in is `create_copy_of`.
 ///
-pub fn create<'ctx, D>(
-    context: &mut era_compiler_llvm_context::EraVMContext<'ctx, D>,
+pub fn create<'ctx>(
+    context: &mut era_compiler_llvm_context::EraVMContext<'ctx>,
     value: inkwell::values::IntValue<'ctx>,
     input_offset: inkwell::values::IntValue<'ctx>,
     input_length: inkwell::values::IntValue<'ctx>,
     salt: Option<inkwell::values::IntValue<'ctx>>,
-) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
-where
-    D: era_compiler_llvm_context::Dependency,
-{
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
     let create_minimal_proxy_to_block = context.append_basic_block("create_minimal_proxy_to_block");
     let create_from_blueprint_block = context.append_basic_block("create_from_blueprint_block");
     let create_join_block = context.append_basic_block("create_join_block");
@@ -59,15 +56,12 @@ where
 ///
 /// Before Vyper v0.3.4, the built-in was called `create_forwarder_to`.
 ///
-fn create_minimal_proxy_to<'ctx, D>(
-    context: &mut era_compiler_llvm_context::EraVMContext<'ctx, D>,
+fn create_minimal_proxy_to<'ctx>(
+    context: &mut era_compiler_llvm_context::EraVMContext<'ctx>,
     value: inkwell::values::IntValue<'ctx>,
     input_offset: inkwell::values::IntValue<'ctx>,
     salt: Option<inkwell::values::IntValue<'ctx>>,
-) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
-where
-    D: era_compiler_llvm_context::Dependency,
-{
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
     if let Some(vyper_data) = context.vyper_mut() {
         vyper_data.set_is_minimal_proxy_used();
     }
@@ -208,16 +202,13 @@ where
 ///
 /// Makes use of the `EXTCODECOPY` substituted with `EXTCODEHASH` for EraVM.
 ///
-fn create_from_blueprint<'ctx, D>(
-    context: &mut era_compiler_llvm_context::EraVMContext<'ctx, D>,
+fn create_from_blueprint<'ctx>(
+    context: &mut era_compiler_llvm_context::EraVMContext<'ctx>,
     value: inkwell::values::IntValue<'ctx>,
     input_offset: inkwell::values::IntValue<'ctx>,
     input_length: inkwell::values::IntValue<'ctx>,
     salt: Option<inkwell::values::IntValue<'ctx>>,
-) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
-where
-    D: era_compiler_llvm_context::Dependency,
-{
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
     let success_block = context.append_basic_block("create_from_blueprint_success_block");
     let failure_block = context.append_basic_block("create_from_blueprint_failure_block");
     let join_block = context.append_basic_block("create_from_blueprint_join_block");

--- a/src/project/contract/vyper/expression/instruction/exit_to.rs
+++ b/src/project/contract/vyper/expression/instruction/exit_to.rs
@@ -16,13 +16,10 @@ impl ExitTo {
     ///
     /// Converts the entity to an LLVM value.
     ///
-    pub fn into_llvm_value<D>(
+    pub fn into_llvm_value(
         mut self,
-        context: &mut era_compiler_llvm_context::EraVMContext<D>,
-    ) -> anyhow::Result<()>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
+        context: &mut era_compiler_llvm_context::EraVMContext,
+    ) -> anyhow::Result<()> {
         let label_name = self.0.remove(0).try_into_identifier()?;
         if label_name.as_str() == crate::r#const::VARIABLE_IDENTIFIER_RETURN_PC {
             context

--- a/src/project/contract/vyper/expression/instruction/goto.rs
+++ b/src/project/contract/vyper/expression/instruction/goto.rs
@@ -23,14 +23,11 @@ impl Goto {
     ///
     /// Generates the function call code.
     ///
-    pub fn into_function_call<'ctx, D>(
+    pub fn into_function_call<'ctx>(
         self,
-        context: &mut era_compiler_llvm_context::EraVMContext<D>,
+        context: &mut era_compiler_llvm_context::EraVMContext,
         label_name: String,
-    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
+    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>> {
         let function = context
             .get_function(label_name.as_str())
             .ok_or_else(|| anyhow::anyhow!("Function `{label_name}` does not exist"))?;
@@ -59,14 +56,11 @@ impl Goto {
     ///
     /// Generates the block call code.
     ///
-    pub fn into_block_call<'ctx, D>(
+    pub fn into_block_call<'ctx>(
         self,
-        context: &mut era_compiler_llvm_context::EraVMContext<D>,
+        context: &mut era_compiler_llvm_context::EraVMContext,
         label_name: String,
-    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
+    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>> {
         let block = context
             .current_function()
             .borrow()
@@ -106,13 +100,10 @@ impl Goto {
     ///
     /// Converts the entity to an LLVM value.
     ///
-    pub fn into_llvm_value<'ctx, D>(
+    pub fn into_llvm_value<'ctx>(
         mut self,
-        context: &mut era_compiler_llvm_context::EraVMContext<D>,
-    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
+        context: &mut era_compiler_llvm_context::EraVMContext,
+    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>> {
         let label_name = self.0.remove(0).try_into_identifier()?;
 
         if label_name.ends_with(crate::r#const::LABEL_SUFFIX_CLEANUP)

--- a/src/project/contract/vyper/expression/instruction/if.rs
+++ b/src/project/contract/vyper/expression/instruction/if.rs
@@ -33,13 +33,10 @@ impl If {
     ///
     /// Converts the entity to an LLVM value.
     ///
-    pub fn into_llvm_value<'ctx, D>(
+    pub fn into_llvm_value<'ctx>(
         mut self,
-        context: &mut era_compiler_llvm_context::EraVMContext<'ctx, D>,
-    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
+        context: &mut era_compiler_llvm_context::EraVMContext<'ctx>,
+    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>> {
         let main_block = context.append_basic_block("if_main");
         let join_block = context.append_basic_block("if_join");
 

--- a/src/project/contract/vyper/expression/instruction/immutable.rs
+++ b/src/project/contract/vyper/expression/instruction/immutable.rs
@@ -10,15 +10,12 @@ use era_compiler_llvm_context::IContext;
 /// It is a custom Vyper-specific instruction, which is capable of copying an array of immutables
 /// from the immutable storage system contract to the heap.
 ///
-pub fn load_bytes<'ctx, D>(
-    context: &mut era_compiler_llvm_context::EraVMContext<'ctx, D>,
+pub fn load_bytes<'ctx>(
+    context: &mut era_compiler_llvm_context::EraVMContext<'ctx>,
     heap_offset: inkwell::values::IntValue<'ctx>,
     immutable_offset: inkwell::values::IntValue<'ctx>,
     length: inkwell::values::IntValue<'ctx>,
-) -> anyhow::Result<()>
-where
-    D: era_compiler_llvm_context::Dependency,
-{
+) -> anyhow::Result<()> {
     let condition_block = context.append_basic_block("immutable_load_bytes_repeat_condition");
     let body_block = context.append_basic_block("immutable_load_bytes_repeat_body");
     let increment_block = context.append_basic_block("immutable_load_bytes_repeat_increment");

--- a/src/project/contract/vyper/expression/instruction/label.rs
+++ b/src/project/contract/vyper/expression/instruction/label.rs
@@ -131,13 +131,10 @@ impl Label {
     ///
     /// Declares the label block, so all the blocks are predeclared before translating the bodies.
     ///
-    pub fn declare<D>(
+    pub fn declare(
         &self,
-        context: &mut era_compiler_llvm_context::EraVMContext<D>,
-    ) -> anyhow::Result<()>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
+        context: &mut era_compiler_llvm_context::EraVMContext,
+    ) -> anyhow::Result<()> {
         if self.is_empty() || self.can_block_be_ignored() {
             return Ok(());
         }
@@ -186,13 +183,10 @@ impl Label {
     ///
     /// Converts the entity to an LLVM value.
     ///
-    pub fn into_llvm_value<D>(
+    pub fn into_llvm_value(
         mut self,
-        context: &mut era_compiler_llvm_context::EraVMContext<D>,
-    ) -> anyhow::Result<()>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
+        context: &mut era_compiler_llvm_context::EraVMContext,
+    ) -> anyhow::Result<()> {
         if self.is_empty() || self.can_block_be_ignored() {
             return Ok(());
         }

--- a/src/project/contract/vyper/expression/instruction/mod.rs
+++ b/src/project/contract/vyper/expression/instruction/mod.rs
@@ -323,13 +323,10 @@ impl Instruction {
     ///
     /// Translates the specified number of arguments into LLVM values.
     ///
-    fn translate_arguments_llvm<'ctx, D, const N: usize>(
+    fn translate_arguments_llvm<'ctx, const N: usize>(
         arguments: [Box<Expression>; N],
-        context: &mut era_compiler_llvm_context::EraVMContext<'ctx, D>,
-    ) -> anyhow::Result<[inkwell::values::BasicValueEnum<'ctx>; N]>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
+        context: &mut era_compiler_llvm_context::EraVMContext<'ctx>,
+    ) -> anyhow::Result<[inkwell::values::BasicValueEnum<'ctx>; N]> {
         let debug_string = format!("`{arguments:?}`");
 
         let mut values = Vec::with_capacity(N);
@@ -358,13 +355,10 @@ impl Instruction {
     /// Translates the specified number of arguments into representation preserving
     /// original LLL identifiers and constants.
     ///
-    fn translate_arguments<'ctx, D, const N: usize>(
+    fn translate_arguments<'ctx, const N: usize>(
         arguments: [Box<Expression>; N],
-        context: &mut era_compiler_llvm_context::EraVMContext<'ctx, D>,
-    ) -> anyhow::Result<[era_compiler_llvm_context::Value<'ctx>; N]>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
+        context: &mut era_compiler_llvm_context::EraVMContext<'ctx>,
+    ) -> anyhow::Result<[era_compiler_llvm_context::Value<'ctx>; N]> {
         let debug_string = format!("`{arguments:?}`");
 
         let mut values = Vec::with_capacity(N);
@@ -437,13 +431,10 @@ impl Instruction {
     ///
     /// Converts the entity to an LLVM value.
     ///
-    pub fn into_llvm_value<'ctx, D>(
+    pub fn into_llvm_value<'ctx>(
         self,
-        context: &mut era_compiler_llvm_context::EraVMContext<'ctx, D>,
-    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
+        context: &mut era_compiler_llvm_context::EraVMContext<'ctx>,
+    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>> {
         match self {
             Self::With(inner) => inner.into_llvm_value(context),
             Self::Set(inner) => inner.into_llvm_value(context).map(|_| None),
@@ -454,7 +445,7 @@ impl Instruction {
             Self::GoTo(inner) => inner.into_llvm_value(context),
             Self::Exit_To(inner) => inner.into_llvm_value(context).map(|_| None),
             Self::Jump(arguments) => {
-                let _arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
+                let _arguments = Self::translate_arguments_llvm::<1>(arguments, context)?;
                 let block = context.current_function().borrow().return_block();
                 context.build_unconditional_branch(block)?;
                 Ok(None)
@@ -477,7 +468,7 @@ impl Instruction {
             Self::Unique_Symbol(_inner) => Ok(None),
 
             Self::UCLAMP(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 3>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<3>(arguments, context)?;
                 clamp::ordinary(
                     context,
                     arguments[0].into_int_value(),
@@ -488,7 +479,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::CLAMP(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 3>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<3>(arguments, context)?;
                 clamp::ordinary(
                     context,
                     arguments[0].into_int_value(),
@@ -499,7 +490,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::UCLAMPLT(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 clamp::with_predicate(
                     context,
                     arguments[0].into_int_value(),
@@ -509,7 +500,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::UCLAMPLE(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 clamp::with_predicate(
                     context,
                     arguments[0].into_int_value(),
@@ -519,7 +510,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::UCLAMPGT(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 clamp::with_predicate(
                     context,
                     arguments[0].into_int_value(),
@@ -529,7 +520,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::UCLAMPGE(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 clamp::with_predicate(
                     context,
                     arguments[0].into_int_value(),
@@ -539,7 +530,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::CLAMPLT(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 clamp::with_predicate(
                     context,
                     arguments[0].into_int_value(),
@@ -549,7 +540,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::CLAMPLE(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 clamp::with_predicate(
                     context,
                     arguments[0].into_int_value(),
@@ -559,7 +550,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::CLAMPGT(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 clamp::with_predicate(
                     context,
                     arguments[0].into_int_value(),
@@ -569,7 +560,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::CLAMPGE(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 clamp::with_predicate(
                     context,
                     arguments[0].into_int_value(),
@@ -579,7 +570,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::CLAMP_NONZERO(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<1>(arguments, context)?;
                 clamp::with_predicate(
                     context,
                     arguments[0].into_int_value(),
@@ -590,11 +581,11 @@ impl Instruction {
             }
 
             Self::CEIL32(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<1>(arguments, context)?;
                 offset::ceil_32(context, arguments[0].into_int_value()).map(Some)
             }
             Self::SELECT(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 3>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<3>(arguments, context)?;
                 let condition = context.builder().build_int_compare(
                     inkwell::IntPredicate::NE,
                     arguments[0].into_int_value(),
@@ -615,12 +606,12 @@ impl Instruction {
             Self::Var_List(_inner) => Ok(None),
 
             Self::POP(arguments) => {
-                let _arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
+                let _arguments = Self::translate_arguments_llvm::<1>(arguments, context)?;
                 Ok(None)
             }
 
             Self::ADD(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_arithmetic::addition(
                     context,
                     arguments[0].into_int_value(),
@@ -633,7 +624,7 @@ impl Instruction {
                     return Ok(Some(result));
                 }
 
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_arithmetic::subtraction(
                     context,
                     arguments[0].into_int_value(),
@@ -642,7 +633,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::MUL(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_arithmetic::multiplication(
                     context,
                     arguments[0].into_int_value(),
@@ -651,7 +642,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::DIV(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_arithmetic::division(
                     context,
                     arguments[0].into_int_value(),
@@ -660,7 +651,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::MOD(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_arithmetic::remainder(
                     context,
                     arguments[0].into_int_value(),
@@ -669,7 +660,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::SDIV(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_arithmetic::division_signed(
                     context,
                     arguments[0].into_int_value(),
@@ -678,7 +669,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::SMOD(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_arithmetic::remainder_signed(
                     context,
                     arguments[0].into_int_value(),
@@ -688,7 +679,7 @@ impl Instruction {
             }
 
             Self::LT(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_comparison::compare(
                     context,
                     arguments[0].into_int_value(),
@@ -698,7 +689,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::LE(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_comparison::compare(
                     context,
                     arguments[0].into_int_value(),
@@ -708,7 +699,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::GT(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_comparison::compare(
                     context,
                     arguments[0].into_int_value(),
@@ -718,7 +709,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::GE(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_comparison::compare(
                     context,
                     arguments[0].into_int_value(),
@@ -728,7 +719,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::EQ(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_comparison::compare(
                     context,
                     arguments[0].into_int_value(),
@@ -738,7 +729,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::NE(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_comparison::compare(
                     context,
                     arguments[0].into_int_value(),
@@ -748,7 +739,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::ISZERO(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<1>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_comparison::compare(
                     context,
                     arguments[0].into_int_value(),
@@ -758,7 +749,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::SLT(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_comparison::compare(
                     context,
                     arguments[0].into_int_value(),
@@ -768,7 +759,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::SLE(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_comparison::compare(
                     context,
                     arguments[0].into_int_value(),
@@ -778,7 +769,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::SGT(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_comparison::compare(
                     context,
                     arguments[0].into_int_value(),
@@ -788,7 +779,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::SGE(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_comparison::compare(
                     context,
                     arguments[0].into_int_value(),
@@ -799,7 +790,7 @@ impl Instruction {
             }
 
             Self::OR(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_bitwise::or(
                     context,
                     arguments[0].into_int_value(),
@@ -808,7 +799,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::XOR(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_bitwise::xor(
                     context,
                     arguments[0].into_int_value(),
@@ -817,7 +808,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::NOT(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<1>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_bitwise::xor(
                     context,
                     arguments[0].into_int_value(),
@@ -826,7 +817,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::AND(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_bitwise::and(
                     context,
                     arguments[0].into_int_value(),
@@ -835,7 +826,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::SHL(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_bitwise::shift_left(
                     context,
                     arguments[0].into_int_value(),
@@ -844,7 +835,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::SHR(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_bitwise::shift_right(
                     context,
                     arguments[0].into_int_value(),
@@ -853,7 +844,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::SAR(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_bitwise::shift_right_arithmetic(
                     context,
                     arguments[0].into_int_value(),
@@ -862,7 +853,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::BYTE(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_bitwise::byte(
                     context,
                     arguments[0].into_int_value(),
@@ -872,7 +863,7 @@ impl Instruction {
             }
 
             Self::ADDMOD(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 3>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<3>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_math::add_mod(
                     context,
                     arguments[0].into_int_value(),
@@ -882,7 +873,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::MULMOD(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 3>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<3>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_math::mul_mod(
                     context,
                     arguments[0].into_int_value(),
@@ -892,7 +883,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::EXP(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_math::exponent(
                     context,
                     arguments[0].into_int_value(),
@@ -901,7 +892,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::SIGNEXTEND(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_math::sign_extend(
                     context,
                     arguments[0].into_int_value(),
@@ -911,7 +902,7 @@ impl Instruction {
             }
 
             Self::SHA3(arguments) | Self::KECCAK256(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_crypto::sha3(
                     context,
                     arguments[0].into_int_value(),
@@ -920,7 +911,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::SHA3_32(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<1>(arguments, context)?;
 
                 let pointer_one = era_compiler_llvm_context::Pointer::new_with_offset(
                     context,
@@ -939,7 +930,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::SHA3_64(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
 
                 let pointer_one = era_compiler_llvm_context::Pointer::new_with_offset(
                     context,
@@ -967,7 +958,7 @@ impl Instruction {
             }
 
             Self::MLOAD(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<1>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_memory::load(
                     context,
                     arguments[0].into_int_value(),
@@ -975,7 +966,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::MSTORE(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_memory::store(
                     context,
                     arguments[0].into_int_value(),
@@ -984,7 +975,7 @@ impl Instruction {
                 .map(|_| None)
             }
             Self::MSTORE8(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_memory::store_byte(
                     context,
                     arguments[0].into_int_value(),
@@ -993,7 +984,7 @@ impl Instruction {
                 .map(|_| None)
             }
             Self::MCOPY(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 3>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<3>(arguments, context)?;
                 let destination = era_compiler_llvm_context::Pointer::new_with_offset(
                     context,
                     era_compiler_llvm_context::EraVMAddressSpace::Heap,
@@ -1020,7 +1011,7 @@ impl Instruction {
             }
 
             Self::SLOAD(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<1>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_storage::load(
                     context,
                     arguments[0].into_int_value(),
@@ -1028,7 +1019,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::SSTORE(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_storage::store(
                     context,
                     arguments[0].into_int_value(),
@@ -1037,7 +1028,7 @@ impl Instruction {
                 .map(|_| None)
             }
             Self::TLOAD(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<1>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_storage::transient_load(
                     context,
                     arguments[0].into_int_value(),
@@ -1045,7 +1036,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::TSTORE(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_storage::transient_store(
                     context,
                     arguments[0].into_int_value(),
@@ -1055,7 +1046,7 @@ impl Instruction {
             }
 
             Self::ILOAD(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<1>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_immutable::load(
                     context,
                     arguments[0].into_int_value(),
@@ -1063,7 +1054,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::ISTORE(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_immutable::store(
                     context,
                     arguments[0].into_int_value(),
@@ -1073,7 +1064,7 @@ impl Instruction {
             }
 
             Self::CALLDATALOAD(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<1>(arguments, context)?;
 
                 match context
                     .code_segment()
@@ -1105,7 +1096,7 @@ impl Instruction {
                 }
             }
             Self::CALLDATACOPY(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 3>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<3>(arguments, context)?;
 
                 let source_offset = match context
                     .code_segment()
@@ -1130,7 +1121,7 @@ impl Instruction {
             }
 
             Self::DLOAD(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<1>(arguments, context)?;
 
                 match context.code_segment() {
                     None => {
@@ -1152,7 +1143,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::DLOADBYTES(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 3>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<3>(arguments, context)?;
 
                 match context.code_segment() {
                     None => {
@@ -1207,7 +1198,7 @@ impl Instruction {
                     );
                 }
 
-                let arguments = Self::translate_arguments_llvm::<D, 3>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<3>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_calldata::copy(
                     context,
                     arguments[0].into_int_value(),
@@ -1221,7 +1212,7 @@ impl Instruction {
                 era_compiler_llvm_context::eravm_evm_return_data::size(context).map(Some)
             }
             Self::RETURNDATACOPY(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 3>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<3>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_return_data::copy(
                     context,
                     arguments[0].into_int_value(),
@@ -1232,7 +1223,7 @@ impl Instruction {
             }
 
             Self::EXTCODESIZE(arguments) => {
-                let arguments = Self::translate_arguments::<D, 1>(arguments, context)?;
+                let arguments = Self::translate_arguments::<1>(arguments, context)?;
                 let mut requested_size = era_compiler_llvm_context::eravm_evm_ext_code::size(
                     context,
                     arguments[0].value.into_int_value(),
@@ -1279,7 +1270,7 @@ impl Instruction {
                 Ok(Some(requested_size))
             }
             Self::EXTCODEHASH(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<1>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_ext_code::hash(
                     context,
                     arguments[0].into_int_value(),
@@ -1287,7 +1278,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::EXTCODECOPY(arguments) => {
-                let arguments = Self::translate_arguments::<D, 4>(arguments, context)?;
+                let arguments = Self::translate_arguments::<4>(arguments, context)?;
 
                 if Some(crate::r#const::EXTCODESIZE_BLUEPRINT_ARGUMENT_NAME)
                     != arguments[0].original.as_deref()
@@ -1346,7 +1337,7 @@ impl Instruction {
             }
 
             Self::LOG0(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 2>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<2>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_event::log(
                     context,
                     arguments[0].into_int_value(),
@@ -1356,7 +1347,7 @@ impl Instruction {
                 .map(|_| None)
             }
             Self::LOG1(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 3>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<3>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_event::log(
                     context,
                     arguments[0].into_int_value(),
@@ -1369,7 +1360,7 @@ impl Instruction {
                 .map(|_| None)
             }
             Self::LOG2(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 4>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<4>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_event::log(
                     context,
                     arguments[0].into_int_value(),
@@ -1382,7 +1373,7 @@ impl Instruction {
                 .map(|_| None)
             }
             Self::LOG3(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 5>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<5>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_event::log(
                     context,
                     arguments[0].into_int_value(),
@@ -1395,7 +1386,7 @@ impl Instruction {
                 .map(|_| None)
             }
             Self::LOG4(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 6>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<6>(arguments, context)?;
                 era_compiler_llvm_context::eravm_evm_event::log(
                     context,
                     arguments[0].into_int_value(),
@@ -1409,7 +1400,7 @@ impl Instruction {
             }
 
             Self::CALL(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 7>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<7>(arguments, context)?;
 
                 let gas = arguments[0].into_int_value();
                 let address = arguments[1].into_int_value();
@@ -1434,7 +1425,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::STATICCALL(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 6>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<6>(arguments, context)?;
 
                 let gas = arguments[0].into_int_value();
                 let address = arguments[1].into_int_value();
@@ -1458,7 +1449,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::DELEGATECALL(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 6>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<6>(arguments, context)?;
 
                 let gas = arguments[0].into_int_value();
                 let address = arguments[1].into_int_value();
@@ -1483,7 +1474,7 @@ impl Instruction {
             }
 
             Self::CREATE(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 3>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<3>(arguments, context)?;
 
                 create::create(
                     context,
@@ -1495,7 +1486,7 @@ impl Instruction {
                 .map(Some)
             }
             Self::CREATE2(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 4>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<4>(arguments, context)?;
 
                 create::create(
                     context,
@@ -1515,7 +1506,7 @@ impl Instruction {
             }
             Self::GAS => era_compiler_llvm_context::eravm_evm_ether_gas::gas(context).map(Some),
             Self::BALANCE(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<1>(arguments, context)?;
 
                 let address = arguments[0].into_int_value();
                 era_compiler_llvm_context::eravm_evm_ether_gas::balance(context, address).map(Some)
@@ -1550,7 +1541,7 @@ impl Instruction {
                     .map(Some)
             }
             Self::BLOCKHASH(arguments) => {
-                let arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
+                let arguments = Self::translate_arguments_llvm::<1>(arguments, context)?;
                 let index = arguments[0].into_int_value();
 
                 era_compiler_llvm_context::eravm_evm_contract_context::block_hash(context, index)
@@ -1570,12 +1561,12 @@ impl Instruction {
             }
 
             Self::CALLCODE(arguments) => {
-                let _arguments = Self::translate_arguments_llvm::<D, 7>(arguments, context)?;
+                let _arguments = Self::translate_arguments_llvm::<7>(arguments, context)?;
                 anyhow::bail!("The `CALLCODE` instruction is not supported")
             }
             Self::PC => anyhow::bail!("The `PC` instruction is not supported"),
             Self::SELFDESTRUCT(arguments) => {
-                let _arguments = Self::translate_arguments_llvm::<D, 1>(arguments, context)?;
+                let _arguments = Self::translate_arguments_llvm::<1>(arguments, context)?;
                 anyhow::bail!("The `SELFDESTRUCT` instruction is not supported")
             }
 
@@ -1588,22 +1579,19 @@ impl Instruction {
     ///
     /// Checks if it is code offset is subtracted from `EXTCODESIZE`.
     ///
-    fn check_sub_code_offset<'ctx, D>(
-        context: &mut era_compiler_llvm_context::EraVMContext<'ctx, D>,
+    fn check_sub_code_offset<'ctx>(
+        context: &mut era_compiler_llvm_context::EraVMContext<'ctx>,
         arguments: &[Box<Expression>; 2],
-    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
+    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>> {
         if let Expression::Instruction(Instruction::EXTCODESIZE(extcodesize_arguments)) =
             *(arguments[0].clone())
         {
             let extcodesize_arguments =
-                Self::translate_arguments::<D, 1>(extcodesize_arguments.to_owned(), context)?;
+                Self::translate_arguments::<1>(extcodesize_arguments.to_owned(), context)?;
             if Some(crate::r#const::EXTCODESIZE_BLUEPRINT_ARGUMENT_NAME)
                 == extcodesize_arguments[0].original.as_deref()
             {
-                let arguments = Self::translate_arguments::<D, 2>(arguments.to_owned(), context)?;
+                let arguments = Self::translate_arguments::<2>(arguments.to_owned(), context)?;
                 return Ok(Some(arguments[0].value));
             }
         }

--- a/src/project/contract/vyper/expression/instruction/offset.rs
+++ b/src/project/contract/vyper/expression/instruction/offset.rs
@@ -9,13 +9,10 @@ use era_compiler_llvm_context::IContext;
 ///
 /// Translates the Vyper LLL-specific `ceil32` instruction.
 ///
-pub fn ceil_32<'ctx, D>(
-    context: &mut era_compiler_llvm_context::EraVMContext<'ctx, D>,
+pub fn ceil_32<'ctx>(
+    context: &mut era_compiler_llvm_context::EraVMContext<'ctx>,
     value: inkwell::values::IntValue<'ctx>,
-) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>>
-where
-    D: era_compiler_llvm_context::Dependency,
-{
+) -> anyhow::Result<inkwell::values::BasicValueEnum<'ctx>> {
     let remainder = context.builder().build_int_unsigned_rem(
         value,
         context.field_const(era_compiler_common::BYTE_LENGTH_FIELD as u64),

--- a/src/project/contract/vyper/expression/instruction/repeat.rs
+++ b/src/project/contract/vyper/expression/instruction/repeat.rs
@@ -30,13 +30,10 @@ impl Repeat {
     ///
     /// Converts the entity to an LLVM value.
     ///
-    pub fn into_llvm_value<D>(
+    pub fn into_llvm_value(
         mut self,
-        context: &mut era_compiler_llvm_context::EraVMContext<D>,
-    ) -> anyhow::Result<()>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
+        context: &mut era_compiler_llvm_context::EraVMContext,
+    ) -> anyhow::Result<()> {
         let index_identifier = self.0.remove(0).try_into_identifier()?;
         let start = self.0.remove(0);
         let rounds = self.0.remove(0);

--- a/src/project/contract/vyper/expression/instruction/return.rs
+++ b/src/project/contract/vyper/expression/instruction/return.rs
@@ -23,14 +23,11 @@ impl Return {
     ///
     /// Converts the entity to an LLVM value.
     ///
-    pub fn into_llvm_value<D>(
+    pub fn into_llvm_value(
         self,
-        context: &mut era_compiler_llvm_context::EraVMContext<D>,
-    ) -> anyhow::Result<()>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
-        let arguments = Instruction::translate_arguments_llvm::<D, 2>(self.0, context)?;
+        context: &mut era_compiler_llvm_context::EraVMContext,
+    ) -> anyhow::Result<()> {
+        let arguments = Instruction::translate_arguments_llvm::<2>(self.0, context)?;
         era_compiler_llvm_context::eravm_evm_return::r#return(
             context,
             arguments[0].into_int_value(),

--- a/src/project/contract/vyper/expression/instruction/revert.rs
+++ b/src/project/contract/vyper/expression/instruction/revert.rs
@@ -23,14 +23,11 @@ impl Revert {
     ///
     /// Converts the entity to an LLVM value.
     ///
-    pub fn into_llvm_value<D>(
+    pub fn into_llvm_value(
         self,
-        context: &mut era_compiler_llvm_context::EraVMContext<D>,
-    ) -> anyhow::Result<()>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
-        let arguments = Instruction::translate_arguments_llvm::<D, 2>(self.0, context)?;
+        context: &mut era_compiler_llvm_context::EraVMContext,
+    ) -> anyhow::Result<()> {
+        let arguments = Instruction::translate_arguments_llvm::<2>(self.0, context)?;
         era_compiler_llvm_context::eravm_evm_return::revert(
             context,
             arguments[0].into_int_value(),

--- a/src/project/contract/vyper/expression/instruction/seq.rs
+++ b/src/project/contract/vyper/expression/instruction/seq.rs
@@ -144,13 +144,10 @@ impl Seq {
     ///
     /// Converts the entity to an LLVM value.
     ///
-    pub fn into_llvm_value<'ctx, D>(
+    pub fn into_llvm_value<'ctx>(
         mut self,
-        context: &mut era_compiler_llvm_context::EraVMContext<'ctx, D>,
-    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
+        context: &mut era_compiler_llvm_context::EraVMContext<'ctx>,
+    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>> {
         let (mut labels, expressions) = self.drain_and_split();
 
         for label in labels.iter_mut() {
@@ -173,13 +170,10 @@ impl Seq {
     }
 }
 
-impl<D> era_compiler_llvm_context::EraVMWriteLLVM<D> for Seq
-where
-    D: era_compiler_llvm_context::Dependency,
-{
+impl era_compiler_llvm_context::EraVMWriteLLVM for Seq {
     fn into_llvm(
         mut self,
-        context: &mut era_compiler_llvm_context::EraVMContext<D>,
+        context: &mut era_compiler_llvm_context::EraVMContext,
     ) -> anyhow::Result<()> {
         let current_block = context.basic_block();
 

--- a/src/project/contract/vyper/expression/instruction/set.rs
+++ b/src/project/contract/vyper/expression/instruction/set.rs
@@ -16,13 +16,10 @@ impl Set {
     ///
     /// Converts the entity to an LLVM value.
     ///
-    pub fn into_llvm_value<D>(
+    pub fn into_llvm_value(
         self,
-        context: &mut era_compiler_llvm_context::EraVMContext<D>,
-    ) -> anyhow::Result<()>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
+        context: &mut era_compiler_llvm_context::EraVMContext,
+    ) -> anyhow::Result<()> {
         let [identifier, value] = self.0;
         let identifier = identifier.try_into_identifier()?;
 

--- a/src/project/contract/vyper/expression/instruction/with.rs
+++ b/src/project/contract/vyper/expression/instruction/with.rs
@@ -28,13 +28,10 @@ impl With {
     ///
     /// Converts the entity to an LLVM value.
     ///
-    pub fn into_llvm_value<'ctx, D>(
+    pub fn into_llvm_value<'ctx>(
         self,
-        context: &mut era_compiler_llvm_context::EraVMContext<'ctx, D>,
-    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
+        context: &mut era_compiler_llvm_context::EraVMContext<'ctx>,
+    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>> {
         let [identifier, value, block] = self.0;
         let identifier = identifier.try_into_identifier()?;
 

--- a/src/project/contract/vyper/expression/mod.rs
+++ b/src/project/contract/vyper/expression/mod.rs
@@ -134,13 +134,10 @@ impl Expression {
     ///
     /// Converts the entity to an LLVM value.
     ///
-    pub fn into_llvm_value<'ctx, D>(
+    pub fn into_llvm_value<'ctx>(
         self,
-        context: &mut era_compiler_llvm_context::EraVMContext<'ctx, D>,
-    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>>
-    where
-        D: era_compiler_llvm_context::Dependency,
-    {
+        context: &mut era_compiler_llvm_context::EraVMContext<'ctx>,
+    ) -> anyhow::Result<Option<inkwell::values::BasicValueEnum<'ctx>>> {
         match self {
             Self::Instruction(inner) => inner.into_llvm_value(context),
             Self::IntegerLiteral(number) => {

--- a/src/project/contract/vyper/function.rs
+++ b/src/project/contract/vyper/function.rs
@@ -53,13 +53,10 @@ impl Function {
     }
 }
 
-impl<D> EraVMWriteLLVM<D> for Function
-where
-    D: era_compiler_llvm_context::Dependency,
-{
+impl EraVMWriteLLVM for Function {
     fn declare(
         &mut self,
-        context: &mut era_compiler_llvm_context::EraVMContext<D>,
+        context: &mut era_compiler_llvm_context::EraVMContext,
     ) -> anyhow::Result<()> {
         let mut argument_types = Vec::with_capacity(1);
         if self.has_return_value() {
@@ -81,7 +78,7 @@ where
 
     fn into_llvm(
         self,
-        context: &mut era_compiler_llvm_context::EraVMContext<D>,
+        context: &mut era_compiler_llvm_context::EraVMContext,
     ) -> anyhow::Result<()> {
         context.set_current_function(self.name.as_str())?;
 

--- a/src/project/dependency_data.rs
+++ b/src/project/dependency_data.rs
@@ -1,9 +1,0 @@
-//!
-//! The contract dependency data.
-//!
-
-///
-/// The contract dependency data.
-///
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, Clone)]
-pub struct DependencyData {}

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -3,7 +3,6 @@
 //!
 
 pub mod contract;
-pub mod dependency_data;
 
 use std::borrow::Cow;
 use std::collections::BTreeMap;


### PR DESCRIPTION
Removes the old dependency handlers in order to support LLVM library linking.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
