### PR TITLE
feat: add `vyper==0.4.1` to supported versions for zkvyper

### DIFF
--- a/src/vyper/mod.rs
+++ b/src/vyper/mod.rs
@@ -43,11 +43,12 @@ impl Compiler {
     pub const DEFAULT_EXECUTABLE_NAME: &'static str = "vyper";
 
     /// The supported versions of `vyper`.
-    pub const SUPPORTED_VERSIONS: [semver::Version; 4] = [
+    pub const SUPPORTED_VERSIONS: [semver::Version; 5] = [
         semver::Version::new(0, 3, 3),
         semver::Version::new(0, 3, 9),
         semver::Version::new(0, 3, 10),
         semver::Version::new(0, 4, 0),
+        semver::Version::new(0, 4, 1),
     ];
 
     /// The first version where we cannot use the optimizer.

--- a/tests/data/contracts/vyper/greeter.vy
+++ b/tests/data/contracts/vyper/greeter.vy
@@ -1,4 +1,4 @@
-# @version ^0.4.0
+# pragma version >=0.4.0
 
 greet: public(String[100])
 

--- a/tests/unit/builtins.rs
+++ b/tests/unit/builtins.rs
@@ -15,6 +15,12 @@ fn create_copy_of_0_4_0() {
     create_copy_of(semver::Version::new(0, 4, 0));
 }
 
+#[test]
+#[should_panic(expected = "Built-in function `create_copy_of` is not supported")]
+fn create_copy_of_0_4_1() {
+    create_copy_of(semver::Version::new(0, 4, 1));
+}
+
 fn create_copy_of(version: semver::Version) {
     let _ = common::build_vyper_combined_json(
         vec![common::TEST_CREATE_COPY_OF_CONTRACT_PATH],

--- a/tests/unit/optimizer.rs
+++ b/tests/unit/optimizer.rs
@@ -22,6 +22,11 @@ fn default_standard_json_0_4_0() {
     default_standard_json(semver::Version::new(0, 4, 0));
 }
 
+#[test]
+fn default_standard_json_0_4_1() {
+    default_standard_json(semver::Version::new(0, 4, 1));
+}
+
 #[cfg(not(target_arch = "aarch64"))]
 #[test]
 fn default_combined_json_0_3_3() {
@@ -38,6 +43,11 @@ fn default_combined_json_0_3_10() {
 #[test]
 fn default_combined_json_0_4_0() {
     default_combined_json(semver::Version::new(0, 4, 0));
+}
+
+#[test]
+fn default_combined_json_0_4_1() {
+    default_combined_json(semver::Version::new(0, 4, 1));
 }
 
 fn default_standard_json(version: semver::Version) {

--- a/tests/unit/unsupported_opcodes.rs
+++ b/tests/unit/unsupported_opcodes.rs
@@ -31,6 +31,12 @@ fn selfdestruct_0_4_0() {
     selfdestruct(semver::Version::new(0, 4, 0));
 }
 
+#[test]
+#[should_panic(expected = "The `SELFDESTRUCT` instruction is not supported")]
+fn selfdestruct_0_4_1() {
+    selfdestruct(semver::Version::new(0, 4, 1));
+}
+
 fn selfdestruct(version: semver::Version) {
     common::build_vyper_combined_json(
         vec![common::TEST_SELFDESTRUCT_CONTRACT_PATH],

--- a/tests/unit/warnings.rs
+++ b/tests/unit/warnings.rs
@@ -22,6 +22,11 @@ fn tx_origin_0_4_0() {
     tx_origin(semver::Version::new(0, 4, 0));
 }
 
+#[test]
+fn tx_origin_0_4_1() {
+    tx_origin(semver::Version::new(0, 4, 1));
+}
+
 fn tx_origin(version: semver::Version) {
     assert!(common::check_warning(
         common::TEST_TX_ORIGIN_CONTRACT_PATH,

--- a/tests/vyper-bin.json
+++ b/tests/vyper-bin.json
@@ -23,6 +23,12 @@
       "protocol": "https",
       "source": "https://github.com/vyperlang/vyper/releases/download/v${VERSION}/vyper.${VERSION}+commit.e9db8d9f.${PLATFORM}",
       "destination": "./vyper-bin/vyper-${VERSION}"
+    },
+    "0.4.1": {
+      "is_enabled": true,
+      "protocol": "https",
+      "source": "https://github.com/vyperlang/vyper/releases/download/v${VERSION}/vyper.${VERSION}+commit.8a93dd27.${PLATFORM}",
+      "destination": "./vyper-bin/vyper-${VERSION}"
     }
   },
   "platforms": {


### PR DESCRIPTION
# What ❔

- Add support for Vyper 0.4.1
- Update tests to include Vyper 0.4.1
- Add Vyper binary to 0.4.1
- Update pragma greeter to PEP440 version specifiers

## Why ❔

Related issue: #156 

Adding support for the latest version of vyper: `0.4.1`. It needs to add this version to the supported list and also adapt tests by adding the `0_4_1` variant.

Moccasin is using `boa-zksync`, which under the hood is calling `zkvyper` to compile the contracts. With the recent [release of vyper==0.4.1](https://github.com/vyperlang/vyper/releases/tag/v0.4.1), it would be a great addition to allow for the latest version of vyper to be compiled for zksync.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
