### PR TITLE
fix: set the stack limit back to 64 MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Set the stack size limit for all threads to 64 MB
 - Updated to Rust v1.85.1
 
 ## [1.5.9] - 2025-01-09

--- a/src/const.rs
+++ b/src/const.rs
@@ -11,6 +11,9 @@ use lazy_static::lazy_static;
 /// The default executable name.
 pub static DEFAULT_EXECUTABLE_NAME: &str = "zkvyper";
 
+/// The worker thread stack size.
+pub const WORKER_THREAD_STACK_SIZE: usize = 16 * 1024 * 1024;
+
 /// The `FREE_VAR_SPACE` offset.
 pub const OFFSET_FREE_VAR_SPACE: usize = 0;
 

--- a/src/const.rs
+++ b/src/const.rs
@@ -12,7 +12,7 @@ use lazy_static::lazy_static;
 pub static DEFAULT_EXECUTABLE_NAME: &str = "zkvyper";
 
 /// The worker thread stack size.
-pub const WORKER_THREAD_STACK_SIZE: usize = 16 * 1024 * 1024;
+pub const WORKER_THREAD_STACK_SIZE: usize = 64 * 1024 * 1024;
 
 /// The `FREE_VAR_SPACE` offset.
 pub const OFFSET_FREE_VAR_SPACE: usize = 0;

--- a/src/zkvyper/main.rs
+++ b/src/zkvyper/main.rs
@@ -11,9 +11,6 @@ use clap::Parser;
 
 use self::arguments::Arguments;
 
-/// The rayon worker stack size.
-const RAYON_WORKER_STACK_SIZE: usize = 16 * 1024 * 1024;
-
 #[cfg(target_env = "musl")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
@@ -46,7 +43,7 @@ fn main_inner() -> anyhow::Result<()> {
         thread_pool_builder = thread_pool_builder.num_threads(threads);
     }
     thread_pool_builder
-        .stack_size(RAYON_WORKER_STACK_SIZE)
+        .stack_size(era_compiler_vyper::WORKER_THREAD_STACK_SIZE)
         .build_global()
         .expect("Thread pool configuration failure");
 


### PR DESCRIPTION
Sets the stack limit back to 64 MB to increase the resilience of recursive algorithms.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
