### PR TITLE
feat: make IPFS hash and CBOR equivalent again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,21 @@
 # The `zkvyper` changelog
 
-## [Unreleased]
+## [1.5.10] - 2025-04-07
 
 ### Added
 
 - Support for Vyper v0.4.1
+- CBOR payload with the IPFS hash and compiler versions at the end of bytecode
+- The `--no-bytecode-metadata` flag to disable the CBOR metadata
 
 ### Changed
 
 - Set the stack size limit for all threads to 64 MB
 - Updated to Rust v1.85.1
+
+### Deprecated
+
+- The `keccak256` metadata hash type
 
 ## [1.5.9] - 2025-01-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "arrayref"
@@ -290,9 +290,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "shlex",
 ]
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -326,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -362,12 +362,11 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colored"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -375,6 +374,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -591,6 +610,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,13 +623,14 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "era-compiler-common"
-version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#8d33194da0c25b16edc09781103509af939d0a8a"
+version = "2.0.0"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#9bafeabc66d33694409208c51749634a86c1772a"
 dependencies = [
  "anyhow",
  "base58",
  "hex",
  "ipfs-hasher",
+ "semver",
  "serde",
  "serde_arrays",
  "serde_json",
@@ -614,8 +640,8 @@ dependencies = [
 
 [[package]]
 name = "era-compiler-downloader"
-version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#8d33194da0c25b16edc09781103509af939d0a8a"
+version = "2.0.0"
+source = "git+https://github.com/matter-labs/era-compiler-common?branch=main#9bafeabc66d33694409208c51749634a86c1772a"
 dependencies = [
  "anyhow",
  "colored",
@@ -627,8 +653,8 @@ dependencies = [
 
 [[package]]
 name = "era-compiler-llvm-context"
-version = "1.5.0"
-source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#58f13d13c5edabdfa0427d8c7201744cbf8dbcbe"
+version = "2.0.0"
+source = "git+https://github.com/matter-labs/era-compiler-llvm-context?branch=main#4785cde7dbc949d89cd15ebc13fb5d43bd0e2b9a"
 dependencies = [
  "anyhow",
  "era-compiler-common",
@@ -637,7 +663,7 @@ dependencies = [
  "num",
  "semver",
  "serde",
- "thiserror 1.0.64",
+ "thiserror",
  "zkevm_opcode_defs",
 ]
 
@@ -655,7 +681,6 @@ dependencies = [
  "hex",
  "inkwell",
  "lazy_static",
- "mimalloc",
  "normpath",
  "path-slash",
  "predicates",
@@ -672,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -749,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
@@ -861,7 +886,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -925,15 +962,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1228,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1248,7 +1276,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "serde",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -1298,9 +1326,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1357,16 +1385,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d0e07885d6a754b9c7993f2625187ad694ee985d60f23355ff0e7077261502"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,6 +1400,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "litemap"
@@ -1425,15 +1449,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "mimalloc"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99585191385958383e13f6b822e6b6d8d9cf928e7d286ceb092da92b43c87bc1"
-dependencies = [
- "libmimalloc-sys",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,9 +1456,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
 dependencies = [
  "adler2",
 ]
@@ -1455,7 +1470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -1613,9 +1628,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1654,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",
@@ -1679,15 +1694,17 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.12"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
+checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
  "byte-slice-cast",
+ "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
+ "rustversion",
  "serde",
 ]
 
@@ -1786,9 +1803,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
@@ -1882,6 +1899,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,7 +1937,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1983,9 +2006,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64",
  "bytes",
@@ -2044,7 +2067,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -2081,7 +2104,20 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.3",
  "windows-sys 0.59.0",
 ]
 
@@ -2190,36 +2226,36 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_arrays"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38636132857f68ec3d5f3eb121166d2af33cb55174c4d5ff645db6165cbef0fd"
+checksum = "94a16b99c5ea4fe3daccd14853ad260ec00ea043b2708d1fd1da3106dcd8d9df"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2228,9 +2264,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -2240,9 +2276,9 @@ dependencies = [
 
 [[package]]
 name = "serde_stacker"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "babfccff5773ff80657f0ecf553c7c516bdc2eb16389c0918b36b73e7015276e"
+checksum = "69c8defe6c780725cce4ec6ad3bd91e321baf6fa4e255df1f31e345d507ef01a"
 dependencies = [
  "serde",
  "stacker",
@@ -2346,9 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
@@ -2467,14 +2503,14 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.3.2",
  "once_cell",
- "rustix",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -2519,31 +2555,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
-dependencies = [
- "thiserror-impl 1.0.64",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.12",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2718,6 +2734,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsigned-varint"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,6 +2821,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2883,53 +2914,49 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "6.0.3"
+version = "7.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+checksum = "2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283"
 dependencies = [
  "either",
- "home",
- "rustix",
+ "env_home",
+ "rustix 0.38.44",
  "winsafe",
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-link"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-link",
 ]
 
 [[package]]
@@ -2952,21 +2979,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -2974,7 +2986,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
@@ -2982,10 +2994,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+name = "windows-targets"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
+]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2994,10 +3016,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3006,10 +3028,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
+name = "windows_aarch64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3018,16 +3040,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
+name = "windows_i686_gnullvm"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3036,10 +3064,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
+name = "windows_i686_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3048,10 +3076,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+name = "windows_x86_64_gnu"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3060,16 +3088,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
 
 [[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -3085,6 +3119,15 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "write16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,19 +17,19 @@ path = "src/zkvyper/main.rs"
 doctest = false
 
 [dependencies]
-clap = { version = "=4.5.21", features = ["derive"] }
-anyhow = "=1.0.89"
-boolinator = "=2.4.0"
-which = "=6.0.3"
-path-slash = "=0.2.1"
-normpath = "=1.3.0"
-rayon = "=1.10.0"
+clap = { version = "4.5", features = ["derive"] }
+anyhow = "1.0"
+boolinator = "2.4"
+which = "7.0"
+path-slash = "0.2"
+normpath = "1.3"
+rayon = "1.10"
 
-serde = { version = "=1.0.210", "features" = [ "derive" ] }
-serde_json = { version = "=1.0.128", features = [ "arbitrary_precision" ] }
-semver = { version = "=1.0.23", features = [ "serde" ] }
-lazy_static = "=1.5.0"
-hex = "=0.4.3"
+serde = { version = "1.0", "features" = [ "derive" ] }
+serde_json = { version = "1.0", features = [ "arbitrary_precision" ] }
+semver = { version = "1.0", features = [ "serde" ] }
+lazy_static = "1.5"
+hex = "0.4"
 
 zkevm_opcode_defs = "=0.150.6"
 
@@ -37,11 +37,12 @@ era-compiler-common = { git = "https://github.com/matter-labs/era-compiler-commo
 era-compiler-llvm-context = { git = "https://github.com/matter-labs/era-compiler-llvm-context", branch = "main" }
 
 [dev-dependencies]
-assert_cmd = "=2.0.16"
-predicates = "=3.1.2"
-tempfile = "=3.12.0"
-test-case = "=3.3.1"
-reqwest = { version = "=0.12.12", features = ["blocking", "json"] }
+assert_cmd = "2.0"
+predicates = "3.1"
+tempfile = "3.19"
+test-case = "3.3"
+reqwest = { version = "0.12", features = ["blocking", "json"] }
+
 era-compiler-downloader = { git = "https://github.com/matter-labs/era-compiler-common", branch = "main" }
 
 [dependencies.inkwell]
@@ -49,6 +50,3 @@ git = "https://github.com/matter-labs-forks/inkwell"
 branch = "llvm-17"
 default-features = false
 features = ["llvm17-0", "no-libffi-linking", "target-eravm", "target-evm"]
-
-[target.'cfg(target_env = "musl")'.dependencies]
-mimalloc = { version = "*", default-features = false }

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Matter Labs
+Copyright (c) 2025 Matter Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LLVM.lock
+++ b/LLVM.lock
@@ -1,2 +1,2 @@
 url = "https://github.com/matter-labs/era-compiler-llvm"
-branch = "main"
+branch = "v1.5.9"

--- a/docs/src/03-combined-json.md
+++ b/docs/src/03-combined-json.md
@@ -71,11 +71,11 @@ The format below is a modification of the original combined JSON output format i
     // Version of vyper.
     "source_version": "0.4.1",
     // Version of zkvyper.
-    "zk_version": "1.5.8"
+    "zk_version": "1.5.10"
   },
   // Version of vyper.
-  "version": "0.4.0",
+  "version": "0.4.1",
   // zkvyper: Version of zkvyper.
-  "zk_version": "1.5.8"
+  "zk_version": "1.5.10"
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,8 @@ use rayon::iter::ParallelIterator;
 pub fn llvm_ir(
     input_paths: Vec<PathBuf>,
     output_selection: &[VyperSelector],
-    metadata_hash_type: era_compiler_common::HashType,
+    metadata_hash_type: era_compiler_common::EraVMMetadataHashType,
+    no_bytecode_metadata: bool,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
     llvm_options: Vec<String>,
     suppressed_warnings: Vec<WarningType>,
@@ -66,6 +67,7 @@ pub fn llvm_ir(
     let mut build = project.compile(
         None,
         metadata_hash_type,
+        no_bytecode_metadata,
         optimizer_settings,
         llvm_options,
         suppressed_warnings,
@@ -81,7 +83,8 @@ pub fn llvm_ir(
 pub fn eravm_assembly(
     input_paths: Vec<PathBuf>,
     output_selection: &[VyperSelector],
-    metadata_hash_type: era_compiler_common::HashType,
+    metadata_hash_type: era_compiler_common::EraVMMetadataHashType,
+    no_bytecode_metadata: bool,
     llvm_options: Vec<String>,
     suppressed_warnings: Vec<WarningType>,
     debug_config: Option<era_compiler_llvm_context::DebugConfig>,
@@ -93,6 +96,7 @@ pub fn eravm_assembly(
     let mut build = project.compile(
         None,
         metadata_hash_type,
+        no_bytecode_metadata,
         optimizer_settings,
         llvm_options,
         suppressed_warnings,
@@ -112,7 +116,8 @@ pub fn standard_output(
     evm_version: Option<era_compiler_common::EVMVersion>,
     enable_decimals: bool,
     search_paths: Option<Vec<String>>,
-    metadata_hash_type: era_compiler_common::HashType,
+    metadata_hash_type: era_compiler_common::EraVMMetadataHashType,
+    no_bytecode_metadata: bool,
     vyper_optimizer_enabled: bool,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
     llvm_options: Vec<String>,
@@ -141,6 +146,7 @@ pub fn standard_output(
     let mut build = project.compile(
         evm_version,
         metadata_hash_type,
+        no_bytecode_metadata,
         optimizer_settings,
         llvm_options,
         suppressed_warnings,
@@ -159,7 +165,8 @@ pub fn combined_json(
     evm_version: Option<era_compiler_common::EVMVersion>,
     enable_decimals: bool,
     search_paths: Option<Vec<String>>,
-    metadata_hash_type: era_compiler_common::HashType,
+    metadata_hash_type: era_compiler_common::EraVMMetadataHashType,
+    no_bytecode_metadata: bool,
     vyper_optimizer_enabled: bool,
     optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
     llvm_options: Vec<String>,
@@ -202,6 +209,7 @@ pub fn combined_json(
     let mut build = project.compile(
         evm_version,
         metadata_hash_type,
+        no_bytecode_metadata,
         optimizer_settings,
         llvm_options,
         suppressed_warnings,

--- a/src/process/input.rs
+++ b/src/process/input.rs
@@ -21,6 +21,8 @@ pub struct Input<'a> {
     pub contract: Cow<'a, Contract>,
     /// The metadata hash.
     pub metadata_hash: Option<era_compiler_common::Hash>,
+    /// Do not include the metadata in the bytecode.
+    pub no_bytecode_metadata: bool,
     /// The output selection flags.
     pub output_selection: Vec<VyperSelector>,
     /// The optimizer settings.
@@ -41,6 +43,7 @@ impl<'a> Input<'a> {
         full_path: Cow<'a, String>,
         contract: Cow<'a, Contract>,
         metadata_hash: Option<era_compiler_common::Hash>,
+        no_bytecode_metadata: bool,
         output_selection: Vec<VyperSelector>,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
         llvm_options: Vec<String>,
@@ -51,6 +54,7 @@ impl<'a> Input<'a> {
             full_path,
             contract,
             metadata_hash,
+            no_bytecode_metadata,
             output_selection,
             optimizer_settings,
             llvm_options,

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -31,6 +31,7 @@ pub fn run() -> anyhow::Result<()> {
             input.contract.into_owned().compile(
                 input.full_path.as_str(),
                 input.metadata_hash,
+                input.no_bytecode_metadata,
                 input.optimizer_settings,
                 input.llvm_options,
                 input.output_selection,

--- a/src/project/contract/llvm_ir.rs
+++ b/src/project/contract/llvm_ir.rs
@@ -35,6 +35,7 @@ impl Contract {
         mut self,
         contract_path: &str,
         metadata_hash: Option<era_compiler_common::Hash>,
+        no_bytecode_metadata: bool,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
         llvm_options: Vec<String>,
         output_selection: Vec<VyperSelector>,
@@ -62,9 +63,21 @@ impl Contract {
                 debug_config,
             );
 
+        let cbor_data = if no_bytecode_metadata {
+            None
+        } else {
+            let cbor_key = crate::r#const::VYPER_PRODUCTION_NAME.to_owned();
+            let cbor_data = vec![(
+                crate::r#const::DEFAULT_EXECUTABLE_NAME.to_owned(),
+                crate::r#const::version().parse().expect("Always valid"),
+            )];
+            Some((cbor_key, cbor_data))
+        };
+
         let build = context.build(
             contract_path,
             metadata_hash,
+            cbor_data,
             output_selection.contains(&VyperSelector::EraVMAssembly),
             false,
         )?;

--- a/src/project/contract/mod.rs
+++ b/src/project/contract/mod.rs
@@ -54,6 +54,7 @@ impl Contract {
         self,
         contract_path: &str,
         metadata_hash: Option<era_compiler_common::Hash>,
+        no_bytecode_metadata: bool,
         optimizer_settings: era_compiler_llvm_context::OptimizerSettings,
         llvm_options: Vec<String>,
         output_selection: Vec<VyperSelector>,
@@ -64,6 +65,7 @@ impl Contract {
             Self::Vyper(inner) => inner.compile(
                 contract_path,
                 metadata_hash,
+                no_bytecode_metadata,
                 optimizer_settings,
                 llvm_options,
                 output_selection,
@@ -73,6 +75,7 @@ impl Contract {
             Self::LLVMIR(inner) => inner.compile(
                 contract_path,
                 metadata_hash,
+                no_bytecode_metadata,
                 optimizer_settings,
                 llvm_options,
                 output_selection,
@@ -82,6 +85,7 @@ impl Contract {
             Self::EraVMAssembly(inner) => inner.compile(
                 contract_path,
                 metadata_hash,
+                no_bytecode_metadata,
                 optimizer_settings,
                 llvm_options,
                 output_selection,

--- a/src/project/contract/vyper/expression/mod.rs
+++ b/src/project/contract/vyper/expression/mod.rs
@@ -94,7 +94,8 @@ impl Expression {
     ///
     pub fn safe_label(label: &str) -> String {
         let identifier = label.replace(['(', ')', '[', ']', ',', ' '], "_");
-        let hash = era_compiler_common::Hash::keccak256(identifier.as_bytes()).to_string();
+        let hash =
+            era_compiler_common::Keccak256Hash::from_slice(identifier.as_bytes()).to_string();
         format!(
             "{identifier}_{}",
             hash.strip_prefix("0x").unwrap_or(hash.as_str())

--- a/src/zkvyper/arguments.rs
+++ b/src/zkvyper/arguments.rs
@@ -98,10 +98,14 @@ pub struct Arguments {
     pub disassemble: bool,
 
     /// Set the metadata hash type.
-    /// Available types: `none`, `keccak256`, `ipfs`.
-    /// The default is `keccak256`.
+    /// Available types: `none`, `ipfs`.
+    /// The default is `ipfs`.
     #[arg(long)]
-    pub metadata_hash: Option<era_compiler_common::HashType>,
+    pub metadata_hash: Option<era_compiler_common::EraVMMetadataHashType>,
+
+    /// Turn off CBOR metadata at the end of bytecode.
+    #[arg(long)]
+    pub no_bytecode_metadata: bool,
 
     /// Dump all IR (LLL, LLVM IR, assembly) to files in the specified directory.
     /// Only for testing and debugging.
@@ -152,6 +156,12 @@ impl Arguments {
 
         if self.input_paths.is_empty() {
             anyhow::bail!("No input files provided.");
+        }
+
+        if let Some(era_compiler_common::EraVMMetadataHashType::Keccak256) = self.metadata_hash {
+            eprintln!(
+                "Warning: `keccak256` metadata hash type is deprecated. Please use `ipfs` instead."
+            );
         }
 
         let modes_count = [

--- a/src/zkvyper/main.rs
+++ b/src/zkvyper/main.rs
@@ -11,10 +11,6 @@ use clap::Parser;
 
 use self::arguments::Arguments;
 
-#[cfg(target_env = "musl")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
 ///
 /// The application entry point.
 ///
@@ -48,7 +44,7 @@ fn main_inner() -> anyhow::Result<()> {
         .expect("Thread pool configuration failure");
 
     inkwell::support::enable_llvm_pretty_stack_trace();
-    era_compiler_llvm_context::initialize_target(era_compiler_common::Target::EraVM); // TODO: pass from CLI
+    era_compiler_llvm_context::initialize_target(era_compiler_common::Target::EraVM);
 
     if arguments.version {
         writeln!(
@@ -121,13 +117,14 @@ fn main_inner() -> anyhow::Result<()> {
 
     let metadata_hash_type = arguments
         .metadata_hash
-        .unwrap_or(era_compiler_common::HashType::Keccak256);
+        .unwrap_or(era_compiler_common::EraVMMetadataHashType::None);
 
     let build = if arguments.llvm_ir {
         era_compiler_vyper::llvm_ir(
             arguments.input_paths,
             output_selection.as_slice(),
             metadata_hash_type,
+            arguments.no_bytecode_metadata,
             optimizer_settings,
             llvm_options,
             suppressed_warnings,
@@ -138,6 +135,7 @@ fn main_inner() -> anyhow::Result<()> {
             arguments.input_paths,
             output_selection.as_slice(),
             metadata_hash_type,
+            arguments.no_bytecode_metadata,
             llvm_options,
             suppressed_warnings,
             debug_config,
@@ -160,6 +158,7 @@ fn main_inner() -> anyhow::Result<()> {
                 arguments.enable_decimals,
                 arguments.search_paths,
                 metadata_hash_type,
+                arguments.no_bytecode_metadata,
                 vyper_optimizer_enabled,
                 optimizer_settings,
                 llvm_options,
@@ -186,6 +185,7 @@ fn main_inner() -> anyhow::Result<()> {
             arguments.enable_decimals,
             arguments.search_paths,
             metadata_hash_type,
+            arguments.no_bytecode_metadata,
             vyper_optimizer_enabled,
             optimizer_settings,
             llvm_options,

--- a/tests/cli/metadata_hash.rs
+++ b/tests/cli/metadata_hash.rs
@@ -1,17 +1,14 @@
 use predicates::prelude::*;
-use test_case::test_case;
 
-use era_compiler_common::HashType;
+use era_compiler_common::EraVMMetadataHashType;
 
 use crate::common;
 
-#[test_case(HashType::None)]
-#[test_case(HashType::Keccak256)]
-#[test_case(HashType::Ipfs)]
-fn default(hash_type: HashType) -> anyhow::Result<()> {
+#[test]
+fn none() -> anyhow::Result<()> {
     let _ = common::setup();
 
-    let hash_type = hash_type.to_string();
+    let hash_type = EraVMMetadataHashType::None.to_string();
     let args = &[
         common::TEST_GREETER_CONTRACT_PATH,
         "--metadata-hash",
@@ -19,7 +16,52 @@ fn default(hash_type: HashType) -> anyhow::Result<()> {
     ];
 
     let result = common::execute_zkvyper(args)?;
-    result.success().stdout(predicate::str::contains("0x"));
+    result
+        .success()
+        .stdout(predicate::str::contains("a165"))
+        .stdout(predicate::str::contains("0023"));
+
+    Ok(())
+}
+
+#[test]
+fn ipfs() -> anyhow::Result<()> {
+    let _ = common::setup();
+
+    let hash_type = EraVMMetadataHashType::IPFS.to_string();
+    let args = &[
+        common::TEST_GREETER_CONTRACT_PATH,
+        "--metadata-hash",
+        hash_type.as_str(),
+    ];
+
+    let result = common::execute_zkvyper(args)?;
+    result
+        .success()
+        .stdout(predicate::str::contains("a264"))
+        .stdout(predicate::str::contains("004c"));
+
+    Ok(())
+}
+
+#[test]
+fn keccak256() -> anyhow::Result<()> {
+    let _ = common::setup();
+
+    let hash_type = EraVMMetadataHashType::Keccak256.to_string();
+    let args = &[
+        common::TEST_GREETER_CONTRACT_PATH,
+        "--metadata-hash",
+        hash_type.as_str(),
+    ];
+
+    let result = common::execute_zkvyper(args)?;
+    result
+        .success()
+        .stdout(predicate::str::contains("0x"))
+        .stderr(predicate::str::contains(
+            "`keccak256` metadata hash type is deprecated. Please use `ipfs` instead.",
+        ));
 
     Ok(())
 }

--- a/tests/cli/mod.rs
+++ b/tests/cli/mod.rs
@@ -15,6 +15,7 @@ mod llvm_ir;
 mod llvm_options;
 mod llvm_verify_each;
 mod metadata_hash;
+mod no_bytecode_metadata;
 mod optimization;
 mod output_dir;
 mod overwrite;

--- a/tests/cli/no_bytecode_metadata.rs
+++ b/tests/cli/no_bytecode_metadata.rs
@@ -1,0 +1,116 @@
+use predicates::prelude::*;
+
+use era_compiler_common::EraVMMetadataHashType;
+
+use crate::common;
+
+#[test]
+fn none() -> anyhow::Result<()> {
+    let _ = common::setup();
+
+    let hash_type = EraVMMetadataHashType::None.to_string();
+    let args = &[
+        common::TEST_GREETER_CONTRACT_PATH,
+        "--metadata-hash",
+        hash_type.as_str(),
+        "--no-bytecode-metadata",
+    ];
+
+    let result = common::execute_zkvyper(args)?;
+    result
+        .success()
+        .stdout(predicate::str::contains("a165").not())
+        .stdout(predicate::str::ends_with("0023").not());
+
+    Ok(())
+}
+
+#[test]
+fn ipfs_vyper() -> anyhow::Result<()> {
+    let _ = common::setup();
+
+    let hash_type = EraVMMetadataHashType::IPFS.to_string();
+    let args = &[
+        common::TEST_GREETER_CONTRACT_PATH,
+        "--metadata-hash",
+        hash_type.as_str(),
+        "--no-bytecode-metadata",
+    ];
+
+    let result = common::execute_zkvyper(args)?;
+    result
+        .success()
+        .stdout(predicate::str::contains("a264").not())
+        .stdout(predicate::str::ends_with("004c").not());
+
+    Ok(())
+}
+
+#[test]
+fn ipfs_llvm_ir() -> anyhow::Result<()> {
+    let _ = common::setup();
+
+    let hash_type = EraVMMetadataHashType::IPFS.to_string();
+    let args = &[
+        "--llvm-ir",
+        common::TEST_LLVM_CONTRACT_PATH,
+        "--metadata-hash",
+        hash_type.as_str(),
+        "--no-bytecode-metadata",
+    ];
+
+    let result = common::execute_zkvyper(args)?;
+    result
+        .success()
+        .stdout(predicate::str::contains("a264").not())
+        .stdout(predicate::str::ends_with("004c").not());
+
+    Ok(())
+}
+
+#[test]
+fn ipfs_eravm_assembly() -> anyhow::Result<()> {
+    let _ = common::setup();
+
+    let hash_type = EraVMMetadataHashType::IPFS.to_string();
+    let args = &[
+        "--eravm-assembly",
+        common::TEST_ERAVM_ASSEMBLY_CONTRACT_PATH,
+        "--metadata-hash",
+        hash_type.as_str(),
+        "--no-bytecode-metadata",
+    ];
+
+    let result = common::execute_zkvyper(args)?;
+    result
+        .success()
+        .stdout(predicate::str::contains("a264").not())
+        .stdout(predicate::str::ends_with("004c").not());
+
+    Ok(())
+}
+
+#[test]
+fn keccak256() -> anyhow::Result<()> {
+    let _ = common::setup();
+
+    let hash_type = EraVMMetadataHashType::Keccak256.to_string();
+    let args = &[
+        common::TEST_GREETER_CONTRACT_PATH,
+        "--metadata-hash",
+        hash_type.as_str(),
+        "--no-bytecode-metadata",
+    ];
+
+    let result = common::execute_zkvyper(args)?;
+    result
+        .success()
+        .stdout(predicate::str::contains("0x"))
+        .stdout(predicate::str::contains("a264").not())
+        .stdout(predicate::str::ends_with("004c").not())
+        .stderr(predicate::str::contains(
+            "`keccak256` metadata hash type is deprecated. Please use `ipfs` instead.",
+        ));
+
+    Ok(())
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -136,7 +136,8 @@ pub fn build_vyper_standard_json(
     let project = Project::try_from_standard_json(output, &vyper.version.default)?;
     let mut build = project.compile(
         None,
-        era_compiler_common::HashType::Ipfs,
+        era_compiler_common::EraVMMetadataHashType::IPFS,
+        false,
         optimizer_settings,
         vec![],
         vec![],
@@ -173,7 +174,8 @@ pub fn build_vyper_combined_json(
 
     let mut build = project.compile(
         None,
-        era_compiler_common::HashType::Ipfs,
+        era_compiler_common::EraVMMetadataHashType::IPFS,
+        false,
         optimizer_settings,
         vec![],
         vec![],


### PR DESCRIPTION
# What ❔

Supports the CBOR payload with `vyper` compiler version at the end of bytecode.

## Why ❔

It is usefull for contract verification purposes.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
