### PR TITLE
ci: deploy docs after successful release by workflow call

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,12 +1,11 @@
 name: Deploy docs
 
 on:
-  release:
-    types: [ released ]
   pull_request:
     paths:
       - 'docs/**'
       - '.github/workflows/deploy-docs.yaml'
+  workflow_call:
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -240,3 +240,9 @@ jobs:
           target_commitish: ${{ steps.release.outputs.full_sha }}
           make_latest: true
           files: releases/**/**
+
+  deploy-docs:
+    if: github.ref_type == 'tag'
+    needs: prepare-release
+    uses: ./.github/workflows/deploy-docs.yaml
+    secrets: inherit


### PR DESCRIPTION
# What ❔

* [x] Deploy documentation after successful release by workflow call.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Default `GITHUB_TOKEN` does not trigger any workflows for release generation. As we shouldn't use any private tokens, try to use `workflow_call` to trigger documentation update.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
